### PR TITLE
CIF-792 - Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  codecov: codecov/codecov@1.0.4
 jobs:
   build:
     docker:
@@ -20,9 +22,12 @@ jobs:
             - ~/.m2
           key: maven-repo-v1-{{ checksum "pom.xml" }}
       - store_test_results:
-          path: target/surefire-reports
+          path: bundles/core/target/surefire-reports
       - store_artifacts:
-          path: target/surefire-reports
+          path: bundles/core/target/surefire-reports
+      - codecov/upload:
+          file: bundles/core/target/jacoco.exec
+          flags: unittests
 
 workflows:
   version: 2

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -199,9 +199,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- CircleCI build workaround -->
-                            <!-- <reuseForks>true</reuseForks>
-                            <useSystemClassLoader>false</useSystemClassLoader> -->
                             <systemPropertyVariables>
                                 <jacoco-agent.destfile>${jacoco.data.file}</jacoco-agent.destfile>
                             </systemPropertyVariables>


### PR DESCRIPTION
* Uses `circleci/openjdk:8u212-jdk-stretch` image, because with 181, the unit tests crashed and I didn't want to change the pom to fix that (see https://discuss.circleci.com/t/circleci-build-failure-on-openjdk-image/26104/2)
* Jacoco coverage is uploaded to codecov (works only when repo is public)
* CircleCI badge in readme