### PR TITLE
CIF-832 - Fix JS error for variants without assets

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/product/v1/product/clientlib/js/product.js
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/product/v1/product/clientlib/js/product.js
@@ -65,10 +65,6 @@
         this._element.querySelector(selectors.name).innerText = variant.name;
         this._element.querySelector(selectors.price).innerText = variant.formattedPrice;
         this._element.querySelector(selectors.description).innerHTML = DOMPurify.sanitize(variant.description);
-
-        // TODO: Update assets, this has a dependency on CIF-775
-        // For demo only, the gallery component should handle this based on the incoming event
-        if (variant.assets.length > 0) this._element.querySelector(selectors.mainImage).src = variant.assets[0].path;
     };
 
     function onDocumentReady() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a JavaScript console error that occurred for products and product variants without assets.
```
Uncaught TypeError: Cannot set property 'src' of null
    at Product._onUpdateVariant (clientlib.js:450)
    at VariantSelector._onSelectVariant (clientlib.js:360)
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
