### PR TITLE
CIF-827 - Fix NPE in product model for getDescription

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+import com.adobe.cq.commerce.magento.graphql.ComplexTextValue;
 import com.adobe.cq.commerce.magento.graphql.Query;
 import com.adobe.cq.commerce.magento.graphql.gson.Error;
 import com.adobe.cq.commerce.magento.graphql.gson.QueryDeserializer;
@@ -122,7 +123,7 @@ public class ProductImpl implements Product {
 
     @Override
     public String getDescription() {
-        return this.product.getDescription().getHtml();
+        return this.safeDescription(this.product);
     }
 
     @Override
@@ -291,7 +292,7 @@ public class ProductImpl implements Product {
 
         VariantImpl productVariant = new VariantImpl();
         productVariant.setName(product.getName());
-        productVariant.setDescription(product.getDescription().getHtml());
+        productVariant.setDescription(this.safeDescription(product));
         productVariant.setSku(product.getSku());
         productVariant.setColor(product.getColor());
         productVariant.setCurrency(product.getPrice().getRegularPrice().getAmount().getCurrency().toString());
@@ -394,5 +395,19 @@ public class ProductImpl implements Product {
         }
 
         return null;
+    }
+
+    private String safeDescription(ProductInterface product) {
+        ComplexTextValue description = product.getDescription();
+        if (description == null) {
+            return "";
+        }
+
+        String descriptionHtml = description.getHtml();
+        if (descriptionHtml == null) {
+            return "";
+        }
+
+        return descriptionHtml;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
@@ -400,14 +400,8 @@ public class ProductImpl implements Product {
     private String safeDescription(ProductInterface product) {
         ComplexTextValue description = product.getDescription();
         if (description == null) {
-            return "";
+            return null;
         }
-
-        String descriptionHtml = description.getHtml();
-        if (descriptionHtml == null) {
-            return "";
-        }
-
-        return descriptionHtml;
+        return description.getHtml();
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImplTest.java
@@ -161,7 +161,7 @@ public class ProductImplTest {
 
         Whitebox.setInternalState(this.slingModel, "product", product);
 
-        Assert.assertEquals("", this.slingModel.getDescription());
+        Assert.assertNull(this.slingModel.getDescription());
     }
 
     @Test
@@ -173,7 +173,7 @@ public class ProductImplTest {
 
         Whitebox.setInternalState(this.slingModel, "product", product);
 
-        Assert.assertEquals("", this.slingModel.getDescription());
+        Assert.assertNull(this.slingModel.getDescription());
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImplTest.java
@@ -14,8 +14,10 @@
 
 package com.adobe.cq.commerce.core.components.internal.models.v1.product;
 
+import com.adobe.cq.commerce.core.components.models.product.Product;
 import com.adobe.cq.commerce.core.components.models.product.Variant;
 import com.adobe.cq.commerce.core.components.models.product.VariantAttribute;
+import com.adobe.cq.commerce.magento.graphql.ComplexTextValue;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableProduct;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableProductOptions;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableProductOptionsValues;
@@ -150,6 +152,41 @@ public class ProductImplTest {
         Assert.assertEquals(2, first.getValues().size());
         Assert.assertEquals("Value A", first.getValues().get(0).getLabel());
         Assert.assertEquals("Value B", first.getValues().get(1).getLabel());
+    }
+
+    @Test
+    public void testSafeDescriptionWithNull() {
+        SimpleProduct product = mock(SimpleProduct.class, RETURNS_DEEP_STUBS);
+        when(product.getDescription()).thenReturn(null);
+
+        Whitebox.setInternalState(this.slingModel, "product", product);
+
+        Assert.assertEquals("", this.slingModel.getDescription());
+    }
+
+    @Test
+    public void testSafeDescriptionHtmlNull() {
+        SimpleProduct product = mock(SimpleProduct.class, RETURNS_DEEP_STUBS);
+        ComplexTextValue value = mock(ComplexTextValue.class, RETURNS_DEEP_STUBS);
+        when(value.getHtml()).thenReturn(null);
+        when(product.getDescription()).thenReturn(value);
+
+        Whitebox.setInternalState(this.slingModel, "product", product);
+
+        Assert.assertEquals("", this.slingModel.getDescription());
+    }
+
+    @Test
+    public void testSafeDescription() {
+        String sampleString = "<strong>abc</strong>";
+        SimpleProduct product = mock(SimpleProduct.class, RETURNS_DEEP_STUBS);
+        ComplexTextValue value = mock(ComplexTextValue.class, RETURNS_DEEP_STUBS);
+        when(value.getHtml()).thenReturn(sampleString);
+        when(product.getDescription()).thenReturn(value);
+
+        Whitebox.setInternalState(this.slingModel, "product", product);
+
+        Assert.assertEquals(sampleString, this.slingModel.getDescription());
     }
 
 }


### PR DESCRIPTION
## Description
Fixed NullPointerException that might occur when calling `getDescription` for a product or product variant.

```
Caused by: java.lang.NullPointerException: null
	at com.adobe.cq.commerce.core.components.internal.models.v1.product.ProductImpl.getDescription(ProductImpl.java:122) [com.adobe.cq.commerce.components.core:0.0.1.SNAPSHOT]
```
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
