### PR TITLE
CIF-828 Warnings in error.log when page opened in page editor

### DIFF
--- a/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/policies/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/policies/.content.xml
@@ -109,7 +109,7 @@
                 <productlist jcr:primaryType="nt:unstructured">
                     <v1 jcr:primaryType="nt:unstructured">
                         <productlist jcr:primaryType="nt:unstructured">
-                            <policy_1554126119277
+                            <default
                                 jcr:lastModified="{Date}2019-04-01T15:42:05.554+02:00"
                                 jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
@@ -117,7 +117,7 @@
                                 sling:resourceType="wcm/core/components/policy/policy"
                                 showTitle="true">
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
-                            </policy_1554126119277>
+                            </default>
                         </productlist>
                     </v1>
                 </productlist>

--- a/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/template-types/empty-page-template/policies/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/template-types/empty-page-template/policies/.content.xml
@@ -15,18 +15,6 @@
                 cq:policy="wcm/foundation/components/responsivegrid/cif-template-policy"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mapping">
-                <cif jcr:primaryType="nt:unstructured">
-                    <components jcr:primaryType="nt:unstructured">
-                        <product jcr:primaryType="nt:unstructured">
-                            <v1 jcr:primaryType="nt:unstructured">
-                                <product
-                                    cq:policy="cif/components/product/v1/product/css-styling-policy"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="wcm/core/components/policies/mapping"/>
-                            </v1>
-                        </product>
-                    </components>
-                </cif>
             </responsivegrid>
         </root>
     </jcr:content>

--- a/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/templates/category-page/policies/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/templates/category-page/policies/.content.xml
@@ -15,19 +15,12 @@
                 cq:policy="wcm/foundation/components/responsivegrid/default"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mapping">
-                <cif jcr:primaryType="nt:unstructured">
-                    <components jcr:primaryType="nt:unstructured">
-                        <productlist jcr:primaryType="nt:unstructured">
-                            <v1 jcr:primaryType="nt:unstructured">
-                                <productlist
-                                    cq:policy="cif/components/productlist/v1/productlist/css-styling-policy"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="wcm/core/components/policies/mapping"/>
-                            </v1>
-                        </productlist>
-                    </components>
-                </cif>
             </responsivegrid>
+            <product-list-container jcr:primaryType="nt:unstructured">
+                <productlist jcr:primaryType="nt:unstructured"
+                             cq:policy="venia/components/commerce/productlist/v1/productlist/default"
+                             sling:resourceType="wcm/core/components/policies/mapping"/>
+            </product-list-container>
         </root>
     </jcr:content>
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/templates/search-results/policies/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/conf/venia/settings/wcm/templates/search-results/policies/.content.xml
@@ -15,18 +15,6 @@
                 cq:policy="wcm/foundation/components/responsivegrid/policy_543301810849945"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mapping">
-                <cif jcr:primaryType="nt:unstructured">
-                    <components jcr:primaryType="nt:unstructured">
-                        <product jcr:primaryType="nt:unstructured">
-                            <v1 jcr:primaryType="nt:unstructured">
-                                <product
-                                    cq:policy="cif/components/product/v1/product/css-styling-policy"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="wcm/core/components/policies/mapping"/>
-                            </v1>
-                        </product>
-                    </components>
-                </cif>
             </responsivegrid>
         </root>
     </jcr:content>

--- a/ui.content/src/main/content/jcr_root/content/venia/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/.content.xml
@@ -13,6 +13,7 @@
         cq:cifProductPage="/content/venia/products/product-page"
         cq:cifSearchResultsPage="/content/venia/language-masters/en/search"
         cq:graphqlClient="default"
+        cq:deviceGroups="[mobile/groups/responsive]"
         jcr:primaryType="cq:PageContent"
         jcr:title="AEM Venia Experience"
         sling:resourceType="core/wcm/components/page/v2/page"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the Warnings in error.log "Ignoring reference to /conf/venia/settings from /conf/venia/settings - Probably misconfigured as it ends with '/settings'"

## Related Issue

CIF-828

## Motivation and Context

See description, fixed annoying log warning message if pages are open in AEM editor.

## How Has This Been Tested?

Manually by watching the logs and make sure the message disappears.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.