### PR TITLE
CIF-722 - Remove obsolete properties

### DIFF
--- a/ui.content/src/main/content/jcr_root/content/venia/language-masters/en/products/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/language-masters/en/products/.content.xml
@@ -6,7 +6,6 @@
         jcr:primaryType="cq:PageContent"
         jcr:title="Catalog Page"
         sling:resourceType="venia/components/structure/catalogpage/v1/catalogpage"
-        catalogRoot="{Boolean}true"
         showMainCategories="{Boolean}true"/>
     <category-page/>
     <product-page/>

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/.content.xml
@@ -10,7 +10,7 @@
         cq:lastRolledoutBy="admin"
         cq:propertyInheritanceCancelled="[jcr:language]"
         cq:template="/conf/venia/settings/wcm/templates/landing-page"
-        jcr:language="en_us"
+        jcr:language="en_US"
         jcr:mixinTypes="[cq:LiveRelationship,cq:LiveSync,cq:PropertyLiveSyncCancelled]"
         jcr:primaryType="cq:PageContent"
         jcr:title="English"

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/products/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/products/.content.xml
@@ -11,7 +11,6 @@
         jcr:primaryType="cq:PageContent"
         jcr:title="Catalog Page"
         sling:resourceType="venia/components/structure/catalogpage/v1/catalogpage"
-        catalogRoot="{Boolean}true"
         magentoRootCategoryId="4"
         showMainCategories="{Boolean}true"/>
     <category-page/>


### PR DESCRIPTION
## Description
Updated feedback from verification. 
* Remove obsolete `catalogRoot` property.
* Fix `jcr:language` language tag.

For reference: The refsquad is recommending to use the Page API to get the language (https://git.corp.adobe.com/CQ/wcm/blob/master/bundles/cq-wcm-api/src/main/java/com/day/cq/wcm/api/Page.java#L357).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
