### PR TITLE
CIF-738 - Add missing dependency to authoring tooling

### DIFF
--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -133,6 +133,11 @@
                             <name>cq-ui-wcm-editor-content</name>
                             <version>(1.0.138,)</version>
                         </dependency>
+                        <dependency>
+                            <group>day/cq60/product</group>
+                            <name>cif-connector-content</name>
+                            <version>0.1.1</version>
+                        </dependency>
                     </dependencies>
                 </configuration>
             </plugin>
@@ -144,6 +149,18 @@
             </plugin>
         </plugins>
     </build>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.adobe.commerce.cif</groupId>
+            <artifactId>cif-connector-content</artifactId>
+            <version>0.1.1</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <!-- ====================================================================== -->
     <!-- P R O F I L E S                                                        -->
     <!-- ====================================================================== -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As discussed, the components are using `cifcategoryfield` and `cifproductfield` components that are in the https://github.com/adobe/commerce-cif-connector project. Therefore I added a dependency to the content package that includes the pickers to the content package that includes the components.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
