### PR TITLE
Fix for CIF-907

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
@@ -83,12 +83,14 @@ public class ProductListImpl implements ProductList {
         showTitle = properties.get(PN_SHOW_TITLE, currentStyle.get(PN_SHOW_TITLE, SHOW_TITLE_DEFAULT));
         navPageSize = properties.get(PN_PAGE_SIZE, currentStyle.get(PN_PAGE_SIZE, PAGE_SIZE_DEFAULT));
 
+        setNavPageCursor();
+
         // get product template page
         productPage = Utils.getProductPage(currentPage);
         if (productPage == null) {
             productPage = currentPage;
         }
-        
+
         // Parse category id from URL
         final Integer categoryId = parseCategoryId();
 
@@ -251,6 +253,25 @@ public class ProductListImpl implements ProductList {
      * @return void
      */
     void setupPagination() {
+        this.navPagePrev = (this.navPageCursor <= 1) ? 1 : (this.navPageCursor - 1);
+        if ((this.getTotalCount() % this.navPageSize) == 0) {
+            this.navPages = new int[(this.getTotalCount() / this.navPageSize)];
+            this.navPageNext = (this.navPageCursor < (this.getTotalCount() / this.navPageSize)) ? (this.navPageCursor + 1) : this.navPageCursor;
+        } else {
+            this.navPages = new int[(this.getTotalCount() / this.navPageSize) + 1];
+            this.navPageNext = (this.navPageCursor < ((this.getTotalCount() / this.navPageSize) + 1)) ? (this.navPageCursor + 1) : this.navPageCursor;
+        }
+        for (int i = 0; i < this.navPages.length; i++) {
+            this.navPages[i] = (i + 1);
+        }
+    }
+
+    /**
+     * Sets value of navPageCursor from URL param if provided, else keeps it to default 1
+     *
+     * @return void
+     */
+    void setNavPageCursor() {
         //check if pageCursor available in queryString, already set to 1 if not.
         if (request.getParameter("page") != null) {
             try {
@@ -262,17 +283,6 @@ public class ProductListImpl implements ProductList {
             } catch (NumberFormatException nfe) {
                 LOGGER.warn("non-parseable value for CGI variable page encountered, keeping navPageCursor value to default ");
             }
-        }
-        this.navPagePrev = (this.navPageCursor <= 1) ? 1 : (this.navPageCursor - 1);
-        if ((this.getTotalCount() % this.navPageSize) == 0) {
-            this.navPages = new int[(this.getTotalCount() / this.navPageSize)];
-            this.navPageNext = (this.navPageCursor < (this.getTotalCount() / this.navPageSize)) ? (this.navPageCursor + 1) : this.navPageCursor;
-        } else {
-            this.navPages = new int[(this.getTotalCount() / this.navPageSize) + 1];
-            this.navPageNext = (this.navPageCursor < ((this.getTotalCount() / this.navPageSize) + 1)) ? (this.navPageCursor + 1) : this.navPageCursor;
-        }
-        for (int i = 0; i < this.navPages.length; i++) {
-            this.navPages[i] = (i + 1);
         }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
@@ -118,6 +118,7 @@ public class ProductListImplTest {
 
         when(incomingRequest.getParameter("page")).thenReturn("" + 1);
         Whitebox.setInternalState(this.slingModel, "request", incomingRequest);
+        ((ProductListImpl) this.slingModel).setNavPageCursor();
         ((ProductListImpl) this.slingModel).setupPagination();
 
         Assert.assertTrue(this.slingModel.getCurrentNavPage() == 1);
@@ -126,6 +127,7 @@ public class ProductListImplTest {
 
         when(incomingRequest.getParameter("page")).thenReturn("" + 2);
         Whitebox.setInternalState(this.slingModel, "request", incomingRequest);
+        ((ProductListImpl) this.slingModel).setNavPageCursor();
         ((ProductListImpl) this.slingModel).setupPagination();
 
         Assert.assertTrue(this.slingModel.getCurrentNavPage() == 2);
@@ -134,6 +136,7 @@ public class ProductListImplTest {
 
         when(incomingRequest.getParameter("page")).thenReturn("" + 3);
         Whitebox.setInternalState(this.slingModel, "request", incomingRequest);
+        ((ProductListImpl) this.slingModel).setNavPageCursor();
         ((ProductListImpl) this.slingModel).setupPagination();
 
         Assert.assertTrue(this.slingModel.getCurrentNavPage() == 3);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Page navigation was not directing to correct page, instead only page1 was loaded for all links.

## Description

Fetch category was being called before Page cursor's correct value was set from URL param, Appropriate logic taken out of `setupPagination()` and included in `setNavPageCursor()`  and called in right sequence, Test method also updated.

## Related Issue

fixes issue CIF-907 

## Motivation and Context

Fixes bug reported in CIF-907

## How Has This Been Tested?

Automated test cases and manual testing on Firefox, Chrome.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
