### PR TITLE
Fix path of cif.cart cookie

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/PageContext.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/PageContext.js
@@ -67,7 +67,7 @@ let PageContext = (function(document) {
                 pageMask.classList.remove('mask__root_active');
             },
             setCartInfoCookie: function({ cartId, cartQuote }) {
-                document.cookie = `${cookieName}=${cartId}#${cartQuote}`;
+                document.cookie = `${cookieName}=${cartId}#${cartQuote};path=/`;
             }
         };
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before that fix, the `cif.cart` cookie was set on the path the user first enters the page. As long as the user enters the page via the navigation root, everything is fine. However, if a user visits the page a first time via a product page, the cart cookie is set on that page and not visible to anything above in the hierarchy. This leads to multiple cart cookies.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
