### PR TITLE
CIF-932 - The navigation component does no longer work with the Luma …

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 
@@ -144,12 +145,13 @@ public class NavigationImpl implements Navigation {
             return;
         }
 
-        final List<CategoryTree> children = graphQLCategoryProvider.getChildCategories(rootCategoryId, structureDepth);
-        if (children.isEmpty()) {
+        List<CategoryTree> children = graphQLCategoryProvider.getChildCategories(rootCategoryId, structureDepth);
+        if (children == null || children.isEmpty()) {
             LOGGER.warn("Magento top categories not found");
             return;
         }
 
+        children = children.stream().filter(c -> c != null && c.getName() != null).collect(Collectors.toList());
         children.sort(Comparator.comparing(CategoryTree::getPosition));
 
         String categoryPagePath = categoryPage.getPath();
@@ -184,8 +186,9 @@ public class NavigationImpl implements Navigation {
         @Override
         public List<NavigationItem> getItems() {
             final List<com.adobe.cq.wcm.core.components.models.NavigationItem> children = wcmItem.getChildren();
-            if (children == null)
+            if (children == null) {
                 return Collections.emptyList();
+            }
 
             List<NavigationItem> items = new ArrayList<>();
             for (com.adobe.cq.wcm.core.components.models.NavigationItem item : children) {
@@ -218,11 +221,12 @@ public class NavigationImpl implements Navigation {
                 return Collections.emptyList();
             }
 
-            final List<CategoryTree> children = category.getChildren();
+            List<CategoryTree> children = category.getChildren();
             if (children == null || children.isEmpty()) {
                 return Collections.emptyList();
             }
 
+            children = children.stream().filter(c -> c != null && c.getName() != null).collect(Collectors.toList());
             children.sort(Comparator.comparing(CategoryTree::getPosition));
 
             List<NavigationItem> pages = new ArrayList<>();


### PR DESCRIPTION
…catalog

- ensure that each child category has a name

<!--- Provide a general summary of your changes in the Title above -->

The LUMA sample catalog contains "invalid" categories without a name and a url_path. These should be ignored by the navigation menu.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
