### PR TITLE
Enforce code coverage for Java and Karma unit tests

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -7,11 +7,13 @@ coverage:
         target: 55%
         threshold: null
         base: auto
+        flags: unittests
       karma:
         enabled: true
         target: 91%
         threshold: null
         base: auto
+        flags: karma
     patch:
       default: off
       unittests:
@@ -19,8 +21,10 @@ coverage:
         target: 55%
         threshold: null
         base: auto
+        flags: unittests
       karma:
         enabled: true
         target: 91%
         threshold: null
         base: auto
+        flags: karma

--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  status:
+    project:
+      default: off
+      unittests:
+        enabled: true
+        target: 55%
+        threshold: null
+        base: auto
+      karma:
+        enabled: true
+        target: 91%
+        threshold: null
+        base: auto
+    patch:
+      default: off
+      unittests:
+        enabled: true
+        target: 55%
+        threshold: null
+        base: auto
+      karma:
+        enabled: true
+        target: 91%
+        threshold: null
+        base: auto

--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -10,7 +10,7 @@ coverage:
         flags: unittests
       karma:
         enabled: true
-        target: 91%
+        target: 90%
         threshold: null
         base: auto
         flags: karma
@@ -24,7 +24,7 @@ coverage:
         flags: unittests
       karma:
         enabled: true
-        target: 91%
+        target: 90%
         threshold: null
         base: auto
         flags: karma

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@1.0.5
+
 executors:
   cif_executor:
     docker:
@@ -28,9 +31,9 @@ jobs:
           path: bundles/core/target/surefire-reports
       - store_artifacts:
           path: bundles/core/target/surefire-reports
-      - run:
-          name: Upload Code Coverage
-          command: bash <(curl -s https://codecov.io/bash) -F unittests
+      - codecov/upload:
+          conf: .circleci/codecov.yml
+          flags: unittests
 
   karma:
     docker:
@@ -49,9 +52,9 @@ jobs:
           path: ui.apps/karma-junit
       - store_artifacts:
           path: ui.apps/karma-junit
-      - run:
-          name: Upload Code Coverage
-          command: bash <(curl -s https://codecov.io/bash) -F karma
+      - codecov/upload:
+          conf: .circleci/codecov.yml
+          flags: karma
 
   release:
     executor: cif_executor

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -153,26 +153,11 @@
                                                 <limit>
                                                     <counter>INSTRUCTION</counter>
                                                     <value>COVEREDRATIO</value>
-                                                    <minimum>0.0</minimum>
-                                                </limit>
-                                            </limits>
-                                        </rule>
-                                        <rule>
-                                            <element>CLASS</element>
-                                            <limits>
-                                                <limit>
-                                                    <counter>INSTRUCTION</counter>
-                                                    <value>COVEREDRATIO</value>
-                                                    <minimum>0.0</minimum>
+                                                    <minimum>0.55</minimum>
                                                 </limit>
                                             </limits>
                                         </rule>
                                     </rules>
-                                    <excludes>
-                                        <!-- private enum; cannot test valueOf / values -->
-                                        <exclude>**/SocialMediaHelperImpl$WebsiteMetadata$Type.class</exclude>
-                                        <exclude>**/AdaptiveImageServlet$Source.class</exclude>
-                                    </excludes>
                                 </configuration>
                             </execution>
                             <execution>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -151,7 +151,7 @@
                                             <element>BUNDLE</element>
                                             <limits>
                                                 <limit>
-                                                    <counter>INSTRUCTION</counter>
+                                                    <counter>BRANCH</counter>
                                                     <value>COVEREDRATIO</value>
                                                     <minimum>0.55</minimum>
                                                 </limit>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Enable Jacoco coverage check for Java unit tests. This check is automatically performed for every Maven build. Threshold is **55%**.
* Enable Codecov coverage check for Java and Karma unit tests. Thresholds are as follows:

    |                | Java | Karma |
    | -------- | ----- | ------ | 
    | New       | 55%  | 90%   |
    | Existing | 55%  | 90%   |

* In the next weeks we will steadily increase those thresholds.
* Use CircleCI Codecov Orb instead of Codecov bash uploader.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
