### PR TITLE
CIF-939 - fixes the maven central auto-release

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,8 @@
     governing permissions and limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <!-- ====================================================================== -->
@@ -198,6 +199,17 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
             <!-- Maven IntelliJ IDEA Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the maven central auto-release of a staging repository.

## Related Issue

CIF-939

## Motivation and Context

During the last release of version 0.2.0 the artifacts have not been automatically published to maven central repo. The staging repo on Nexus stayed in the open state.

## How Has This Been Tested?

Manually locally be creating a dummy release and pushing it to nexus with `<autoReleaseAfterClose>false</autoReleaseAfterClose>`so nothing was made public. That worked, the project was closed. Snippet from the release log: 
```
[INFO] Performing remote staging...
[INFO]
[INFO]  * Remote staging into staging profile ID "554a1ea838367e"
[INFO]  * Created staging repository with ID "comadobecommercecif-1050".
[INFO]  * Staging repository at https://oss.sonatype.org:443/service/local/staging/deployByRepositoryId/comadobecommercecif-1050
...

Uploaded to ossrh: https://oss.sonatype.org:443/service/local/staging/deployByRepositoryId/comadobecommercecif-1050/com/adobe/commerce/cif/core-cif-components-apps/0.2.2/core-cif-components-apps-0.2.2.pom.asc (488 B at 2.2 kB/s)
[INFO]  * Upload of locally staged artifacts finished.
[INFO]  * Closing staging repository with ID "comadobecommercecif-1050".
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.