### PR TITLE
CIF-942 - Update client-side components to use GraphQL caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .classpath
 .project
 .settings
+.DS_Store
 
 # Ignore Maven stuff
 target/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The latest version of the AEM CIF Core Components, require the below minimum sys
 | 0.2.0               | 6.4.4.0 | 6.5.0   | 2.3.1 / 2.3.2   | 1.8  |
 | 0.1.0               | 6.4.4.0 | 6.5.0   | 2.3.1   | 1.8  |
 
+For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
+
 ### AEM Commerce connector for Magento
 
 This project uses the [AEM Commerce connector for Magento](https://github.com/adobe/commerce-cif-connector) to improve the authoring experience by leveraging the product pickers, product assets view and consoles provided by the connector package.
@@ -45,7 +47,12 @@ This project uses the [AEM Commerce connector for Magento](https://github.com/ad
 
 This project relies on the [AEM Sites Core Components](https://github.com/adobe/aem-core-wcm-components). They are typically installed as part of AEM. If you install AEM without sample content option you have to [deploy them manually](https://github.com/adobe/aem-core-wcm-components#installation) before using the AEM CIF Core Components.
 
-For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
+### GraphQL Caching with Magento 2.3.2
+Starting with 2.3.2, Magento supports cache-able GraphQL requests and starting with version 0.2.1 the CIF core components will use it by default. To make the components work with Magento 2.3.1 you can manually disable this feature in the following locations:
+
+* For client-side components: [CommerceGraphqlApi.js](https://github.com/adobe/aem-core-cif-components/blob/master/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js)
+
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The latest version of the AEM CIF Core Components, require the below minimum sys
 
 | CIF Core Components | AEM 6.4 | AEM 6.5 | Magento | Java |
 | ------------------- | ------- | ------- | ------- | ---- |
+| 0.2.1-SNAPSHOT      | 6.4.4.0 | 6.5.0   | 2.3.2   | 1.8  |
 | 0.2.0               | 6.4.4.0 | 6.5.0   | 2.3.1 / 2.3.2   | 1.8  |
 | 0.1.0               | 6.4.4.0 | 6.5.0   | 2.3.1   | 1.8  |
 

--- a/ui.apps/karma.conf.js
+++ b/ui.apps/karma.conf.js
@@ -28,10 +28,12 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'node_modules/@babel/polyfill/dist/polyfill.js',
       'src/main/content/jcr_root/apps/core/cif/components/commerce/product/**/js/*.js',
       'src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/**/js/*.js',
 
       'src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/PriceFormatter.js',
+      'src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js',
       
       'test/**/*Test.js'
     ],

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -33,7 +33,7 @@ class CommerceGraphqlApi {
         return response.json();
     }
 
-    async _fetchGraphql(query, cached) {
+    async _fetchGraphql(query, ignoreCache = false) {
         // Minimize query
         query = query
             .split('\n')
@@ -42,22 +42,22 @@ class CommerceGraphqlApi {
         query = { query };
 
         let params = {
-            method: cached ? 'GET' : 'POST',
+            method: ignoreCache ? 'POST' : 'GET',
             headers: {
                 'Content-Type': 'application/json'
             }
         };
 
         let url = this.endpoint;
-        if (cached) {
+        if (ignoreCache) {
+            // For un-cached POST request, add query to body
+            params.body = JSON.stringify(query);
+        } else {
             // For cached GET request, add query as query parameters
             let queryString = Object.keys(query)
                 .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
                 .join('&');
             url += '?' + queryString;
-        } else {
-            // For un-cached POST request, add query to body
-            params.body = JSON.stringify(query);
         }
 
         let response = await this._fetch(url, params);
@@ -103,7 +103,7 @@ class CommerceGraphqlApi {
             }
         }`;
 
-        let response = await this._fetchGraphql(query, true);
+        let response = await this._fetchGraphql(query);
         let items = response.data.products.items;
 
         let productsMedia = {};
@@ -167,7 +167,7 @@ class CommerceGraphqlApi {
                 }
             }
         }`;
-        let response = await this._fetchGraphql(query, true);
+        let response = await this._fetchGraphql(query);
 
         // Transform response in a SKU to price map
         let items = response.data.products.items;

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -11,187 +11,183 @@
  *     governing permissions and limitations under the License.
  *
  ******************************************************************************/
+'use strict';
 
-(function() {
-    'use strict';
-    //todo update the proxy rules so that this gets router through the dispatcher
-    const imageUrlPrefix = '/magento/img';
-
-    class CommerceGraphqlApi {
-        constructor(props) {
-            if (!props.endpoint) {
-                throw new Error(
-                    'The commerce API is not properly initialized. The "endpoint" property is missing from the initialization object'
-                );
-            }
-
-            this.endpoint = props.endpoint;
+class CommerceGraphqlApi {
+    constructor(props) {
+        if (!props.endpoint) {
+            throw new Error(
+                'The commerce API is not properly initialized. The "endpoint" property is missing from the initialization object'
+            );
         }
 
-        async _fetch(url, params) {
-            let response = await fetch(url, params);
-            if (!response.ok || response.errors) {
-                let message = await response.text();
-                throw new Error(message);
-            }
-            return response.json();
-        }
-
-        async _fetchGraphql(query, cached) {
-            // Minimize query
-            query = query
-                .split('\n')
-                .map(a => a.trim())
-                .join(' ');
-            query = { query };
-
-            let params = {
-                method: cached ? 'GET' : 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            };
-
-            let url = this.endpoint;
-            if (cached) {
-                // For cached GET request, add query as query parameters
-                let queryString = Object.keys(query)
-                    .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
-                    .join('&');
-                url += '?' + queryString;
-            } else {
-                // For un-cached POST request, add query to body
-                params.body = JSON.stringify(query);
-            }
-
-            let response = await this._fetch(url, params);
-            if (response.data === undefined && response.errors) {
-                throw new Error(JSON.stringify(response.errors));
-            }
-
-            return response;
-        }
-
-        /**
-         * Retrieves the URL of the images for an array of product data
-         * @param productData a dictionary object with the following structure {productName:productSku}.
-         * The productName is used for filtering the query and the product SKU is used to identify the variant for which to retrieve the image
-         * @returns {Promise<any[]>}
-         */
-        async getProductImageUrls(productData) {
-            //ugly but effective
-            let names = Object.keys(productData).reduce((acc, name) => (acc += '"' + name + '",'), '');
-            if (names.length === 0) {
-                return {};
-            }
-            // prettier-ignore
-            const query = `query { 
-                products(filter: {name: {in: [${names.substring(0, names.length - 1)}]}}) {
-                    items {
-                        sku
-                        name
-                        thumbnail {  
-                            url
-                            }
-                        ... on ConfigurableProduct {
-                            variants {
-                                product {
-                                    sku
-                                    thumbnail {  
-                                       url
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }`;
-
-            let response = await this._fetchGraphql(query, true);
-            let items = response.data.products.items;
-
-            let productsMedia = {};
-            items.forEach(item => {
-                let variants = item.variants;
-                if (variants && variants.length > 0) {
-                    let skus = productData[item.name];
-                    let media = variants.filter(v => skus.indexOf(v.product.sku) !== -1);
-                    if (media && media.length > 0) {
-                        media.forEach(v => {
-                            productsMedia[v.product.sku] = v.product.thumbnail.url;
-                        });
-                    }
-                } else {
-                    productsMedia[item.sku] = item.thumbnail.url;
-                }
-            });
-            return productsMedia;
-        }
-
-        /**
-         * Retrieves the prices of the products with the given SKUs and their variants.
-         *
-         * @param {array} skus  Array of product SKUs.
-         * @returns {Promise<any[]>} Returns a map of skus mapped to their prices. The price is an object containing the currency and value.
-         */
-        async getProductPrices(skus, includeVariants) {
-            let skuQuery = '"' + skus.join('", "') + '"';
-
-            // prettier-ignore
-            const variantQuery = `... on ConfigurableProduct {
-                variants {
-                    product {
-                        sku
-                        price {
-                            regularPrice {
-                                amount {
-                                    currency
-                                    value
-                                }
-                            }
-                        }
-                    }
-                }
-            }`;
-
-            // prettier-ignore
-            const query = `query {
-                products(filter: { sku: { in: [${skuQuery}] }} ) {
-                    items {
-                        sku
-                        price {
-                            regularPrice {
-                                amount {
-                                    currency
-                                    value
-                                }
-                            }
-                        }
-                        ${includeVariants ? variantQuery : ''}
-                    }
-                }
-            }`;
-            let response = await this._fetchGraphql(query, true);
-
-            // Transform response in a SKU to price map
-            let items = response.data.products.items;
-            let dict = {};
-            for (let item of items) {
-                dict[item.sku] = item.price.regularPrice.amount;
-
-                // Go through variants
-                if (!item.variants) continue;
-                for (let variant of item.variants) {
-                    dict[variant.product.sku] = variant.product.price.regularPrice.amount;
-                }
-            }
-            return dict;
-        }
+        this.endpoint = props.endpoint;
     }
 
+    async _fetch(url, params) {
+        let response = await fetch(url, params);
+        if (!response.ok || response.errors) {
+            let message = await response.text();
+            throw new Error(message);
+        }
+        return response.json();
+    }
+
+    async _fetchGraphql(query, cached) {
+        // Minimize query
+        query = query
+            .split('\n')
+            .map(a => a.trim())
+            .join(' ');
+        query = { query };
+
+        let params = {
+            method: cached ? 'GET' : 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        };
+
+        let url = this.endpoint;
+        if (cached) {
+            // For cached GET request, add query as query parameters
+            let queryString = Object.keys(query)
+                .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
+                .join('&');
+            url += '?' + queryString;
+        } else {
+            // For un-cached POST request, add query to body
+            params.body = JSON.stringify(query);
+        }
+
+        let response = await this._fetch(url, params);
+        if (response.data === undefined && response.errors) {
+            throw new Error(JSON.stringify(response.errors));
+        }
+
+        return response;
+    }
+
+    /**
+     * Retrieves the URL of the images for an array of product data
+     * @param productData a dictionary object with the following structure {productName:productSku}.
+     * The productName is used for filtering the query and the product SKU is used to identify the variant for which to retrieve the image
+     * @returns {Promise<any[]>}
+     */
+    async getProductImageUrls(productData) {
+        //ugly but effective
+        let names = Object.keys(productData).reduce((acc, name) => (acc += '"' + name + '",'), '');
+        if (names.length === 0) {
+            return {};
+        }
+        // prettier-ignore
+        const query = `query { 
+            products(filter: {name: {in: [${names.substring(0, names.length - 1)}]}}) {
+                items {
+                    sku
+                    name
+                    thumbnail {  
+                        url
+                        }
+                    ... on ConfigurableProduct {
+                        variants {
+                            product {
+                                sku
+                                thumbnail {  
+                                   url
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }`;
+
+        let response = await this._fetchGraphql(query, true);
+        let items = response.data.products.items;
+
+        let productsMedia = {};
+        items.forEach(item => {
+            let variants = item.variants;
+            if (variants && variants.length > 0) {
+                let skus = productData[item.name];
+                let media = variants.filter(v => skus.indexOf(v.product.sku) !== -1);
+                if (media && media.length > 0) {
+                    media.forEach(v => {
+                        productsMedia[v.product.sku] = v.product.thumbnail.url;
+                    });
+                }
+            } else {
+                productsMedia[item.sku] = item.thumbnail.url;
+            }
+        });
+        return productsMedia;
+    }
+
+    /**
+     * Retrieves the prices of the products with the given SKUs and their variants.
+     *
+     * @param {array} skus  Array of product SKUs.
+     * @returns {Promise<any[]>} Returns a map of skus mapped to their prices. The price is an object containing the currency and value.
+     */
+    async getProductPrices(skus, includeVariants) {
+        let skuQuery = '"' + skus.join('", "') + '"';
+
+        // prettier-ignore
+        const variantQuery = `... on ConfigurableProduct {
+            variants {
+                product {
+                    sku
+                    price {
+                        regularPrice {
+                            amount {
+                                currency
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }`;
+
+        // prettier-ignore
+        const query = `query {
+            products(filter: { sku: { in: [${skuQuery}] }} ) {
+                items {
+                    sku
+                    price {
+                        regularPrice {
+                            amount {
+                                currency
+                                value
+                            }
+                        }
+                    }
+                    ${includeVariants ? variantQuery : ''}
+                }
+            }
+        }`;
+        let response = await this._fetchGraphql(query, true);
+
+        // Transform response in a SKU to price map
+        let items = response.data.products.items;
+        let dict = {};
+        for (let item of items) {
+            dict[item.sku] = item.price.regularPrice.amount;
+
+            // Go through variants
+            if (!item.variants) continue;
+            for (let variant of item.variants) {
+                dict[variant.product.sku] = variant.product.price.regularPrice.amount;
+            }
+        }
+        return dict;
+    }
+}
+
+(function() {
     function onDocumentReady() {
         const endpoint = '/magento/graphql';
-
         window.CIF.CommerceGraphqlApi = new CommerceGraphqlApi({ endpoint });
     }
 
@@ -201,3 +197,5 @@
         document.addEventListener('DOMContentLoaded', onDocumentReady);
     }
 })();
+
+export default CommerceGraphqlApi;

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -15,7 +15,7 @@
 
 class CommerceGraphqlApi {
     constructor(props) {
-        if (!props.endpoint) {
+        if (!props || !props.endpoint) {
             throw new Error(
                 'The commerce API is not properly initialized. The "endpoint" property is missing from the initialization object'
             );

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -16,9 +16,9 @@
 import CommerceGraphqlApi from '../../../src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js';
 
 describe('CommerceGraphqlApi', () => {
-
     let graphqlApi;
     let fetchSpy;
+    let fetchGraphqlSpy;
 
     beforeEach(() => {
         fetchSpy = sinon.stub(CommerceGraphqlApi.prototype, '_fetch');
@@ -27,13 +27,18 @@ describe('CommerceGraphqlApi', () => {
 
     afterEach(() => {
         fetchSpy.restore();
-    })
+        fetchGraphqlSpy && fetchGraphqlSpy.restore();
+    });
+
+    it('throws an error if endpoint is missing', () => {
+        assert.throws(() => new CommerceGraphqlApi());
+    });
 
     it('fetches an uncached GraphQL query', () => {
-        const mockResult = { result: 'my-result'};
+        const mockResult = { result: 'my-result' };
         fetchSpy.resolves(mockResult);
 
-        let query = 'abc';
+        let query = 'my-sample-query';
 
         return graphqlApi._fetchGraphql(query, false).then(res => {
             // Verify requests
@@ -53,10 +58,10 @@ describe('CommerceGraphqlApi', () => {
     });
 
     it('fetches a cached GraphQL query', () => {
-        const mockResult = { result: 'my-result'};
+        const mockResult = { result: 'my-result' };
         fetchSpy.resolves(mockResult);
 
-        let query = 'abc';
+        let query = 'my-sample-query';
 
         return graphqlApi._fetchGraphql(query, true).then(res => {
             // Verify requests
@@ -80,15 +85,165 @@ describe('CommerceGraphqlApi', () => {
     });
 
     it('throws an error for GraphQL errors', () => {
+        const mockResult = { errors: [{ message: 'my-error' }] };
+        fetchSpy.resolves(mockResult);
 
+        return graphqlApi._fetchGraphql('sample-query', false).then(
+            () => Promise.reject(new Error('Expected promise rejection')),
+            err => {
+                assert.equal(err.message, JSON.stringify(mockResult.errors));
+            }
+        );
     });
 
-    it('retrieves product prices', () => {
+    it('retrieves product prices without variants', () => {
+        const mockResponse = {
+            data: {
+                products: {
+                    items: [
+                        {
+                            sku: 'sku-a',
+                            price: {
+                                regularPrice: {
+                                    amount: {
+                                        currency: 'USD',
+                                        value: 118
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            sku: 'sku-b',
+                            price: {
+                                regularPrice: {
+                                    amount: {
+                                        currency: 'USD',
+                                        value: 78
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        };
 
+        fetchGraphqlSpy = sinon.stub(CommerceGraphqlApi.prototype, '_fetchGraphql').resolves(mockResponse);
+        graphqlApi = new CommerceGraphqlApi({ endpoint: '/graphql' });
+
+        return graphqlApi.getProductPrices(['sku-a', 'sku-b'], false).then(res => {
+            assert.isTrue(fetchGraphqlSpy.calledOnce);
+
+            // Make sure that query does not contain "variants"
+            let query = fetchGraphqlSpy.firstCall.args[0];
+            assert.notInclude(query, 'variants');
+
+            // Validate price dictionary
+            assert.hasAllKeys(res, ['sku-a', 'sku-b']);
+            assert.equal(res['sku-a'].currency, 'USD');
+            assert.equal(res['sku-a'].value, 118);
+        });
+    });
+
+    it('retrieves product prices with variants', () => {
+        const mockResponse = {
+            data: {
+                products: {
+                    items: [
+                        {
+                            sku: 'sku-a',
+                            price: {
+                                regularPrice: {
+                                    amount: {
+                                        currency: 'USD',
+                                        value: 118
+                                    }
+                                }
+                            },
+                            variants: [
+                                {
+                                    product: {
+                                        sku: 'sku-a-xl',
+                                        price: {
+                                            regularPrice: {
+                                                amount: {
+                                                    currency: 'USD',
+                                                    value: 200
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        };
+
+        fetchGraphqlSpy = sinon.stub(CommerceGraphqlApi.prototype, '_fetchGraphql').resolves(mockResponse);
+        graphqlApi = new CommerceGraphqlApi({ endpoint: '/graphql' });
+
+        return graphqlApi.getProductPrices(['sku-a'], true).then(res => {
+            assert.isTrue(fetchGraphqlSpy.calledOnce);
+
+            // Make sure that query contains "variants"
+            let query = fetchGraphqlSpy.firstCall.args[0];
+            assert.include(query, 'variants');
+
+            // Validate price dictionary
+            assert.hasAllKeys(res, ['sku-a', 'sku-a-xl']);
+            assert.equal(res['sku-a'].currency, 'USD');
+            assert.equal(res['sku-a'].value, 118);
+            assert.equal(res['sku-a-xl'].currency, 'USD');
+            assert.equal(res['sku-a-xl'].value, 200);
+        });
     });
 
     it('retrieves product image urls', () => {
+        const mockResponse = {
+            data: {
+                products: {
+                    items: [
+                        {
+                            sku: 'sku-a',
+                            name: 'product-a',
+                            thumbnail: {
+                                url: '/vsk12-la_main_3.jpg'
+                            },
+                            variants: [
+                                {
+                                    product: {
+                                        sku: 'sku-a-xl',
+                                        thumbnail: {
+                                            url: '/vsk12-la_main_2.jpg'
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            sku: 'sku-b',
+                            name: 'product-b',
+                            thumbnail: {
+                                url: '/vsk02-ll_main_2.jpg'
+                            }
+                        }
+                    ]
+                }
+            }
+        };
 
+        fetchGraphqlSpy = sinon.stub(CommerceGraphqlApi.prototype, '_fetchGraphql').resolves(mockResponse);
+        graphqlApi = new CommerceGraphqlApi({ endpoint: '/graphql' });
+
+        return graphqlApi.getProductImageUrls({ 'product-a': 'sku-a-xl', 'product-b': 'sku-b' }).then(res => {
+            assert.isTrue(fetchGraphqlSpy.calledOnce);
+
+            // Validate price dictionary
+            assert.hasAllKeys(res, ['sku-a-xl', 'sku-b']);
+            assert.equal(res['sku-a-xl'], '/vsk12-la_main_2.jpg');
+            assert.equal(res['sku-b'], '/vsk02-ll_main_2.jpg');
+        });
     });
-
 });

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -240,7 +240,7 @@ describe('CommerceGraphqlApi', () => {
         return graphqlApi.getProductImageUrls({ 'product-a': 'sku-a-xl', 'product-b': 'sku-b' }).then(res => {
             assert.isTrue(fetchGraphqlSpy.calledOnce);
 
-            // Validate price dictionary
+            // Validate image url dictionary
             assert.hasAllKeys(res, ['sku-a-xl', 'sku-b']);
             assert.equal(res['sku-a-xl'], '/vsk12-la_main_2.jpg');
             assert.equal(res['sku-b'], '/vsk02-ll_main_2.jpg');

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+'use strict';
+
+import CommerceGraphqlApi from '../../../src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js';
+
+describe('CommerceGraphqlApi', () => {
+
+    let graphqlApi;
+    let fetchSpy;
+
+    beforeEach(() => {
+        fetchSpy = sinon.stub(CommerceGraphqlApi.prototype, '_fetch');
+        graphqlApi = new CommerceGraphqlApi({ endpoint: '/graphql' });
+    });
+
+    afterEach(() => {
+        fetchSpy.restore();
+    })
+
+    it('fetches an uncached GraphQL query', () => {
+        const mockResult = { result: 'my-result'};
+        fetchSpy.resolves(mockResult);
+
+        let query = 'abc';
+
+        return graphqlApi._fetchGraphql(query, false).then(res => {
+            // Verify requests
+            assert.isTrue(fetchSpy.calledOnce);
+            let fetchArguments = fetchSpy.firstCall.args;
+
+            // Verify request url
+            assert.equal(fetchArguments[0], '/graphql');
+
+            // Verify request parameters
+            assert.equal(fetchArguments[1].method, 'POST');
+            assert.deepEqual(fetchArguments[1].body, JSON.stringify({ query }));
+
+            // Verify result
+            assert.deepEqual(res, mockResult);
+        });
+    });
+
+    it('fetches a cached GraphQL query', () => {
+        const mockResult = { result: 'my-result'};
+        fetchSpy.resolves(mockResult);
+
+        let query = 'abc';
+
+        return graphqlApi._fetchGraphql(query, true).then(res => {
+            // Verify requests
+            assert.isTrue(fetchSpy.calledOnce);
+            let fetchArguments = fetchSpy.firstCall.args;
+
+            // Verify request url
+            assert.include(fetchArguments[0], '/graphql?');
+
+            // verify query parameter
+            let queryParams = new URLSearchParams(fetchArguments[0].substr(8));
+            assert.isTrue(queryParams.has('query'));
+            assert.equal(queryParams.get('query'), query);
+
+            // Verify request parameters
+            assert.equal(fetchArguments[1].method, 'GET');
+
+            // Verify result
+            assert.deepEqual(res, mockResult);
+        });
+    });
+
+    it('throws an error for GraphQL errors', () => {
+
+    });
+
+    it('retrieves product prices', () => {
+
+    });
+
+    it('retrieves product image urls', () => {
+
+    });
+
+});

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -40,7 +40,7 @@ describe('CommerceGraphqlApi', () => {
 
         let query = 'my-sample-query';
 
-        return graphqlApi._fetchGraphql(query, false).then(res => {
+        return graphqlApi._fetchGraphql(query, true).then(res => {
             // Verify requests
             assert.isTrue(fetchSpy.calledOnce);
             let fetchArguments = fetchSpy.firstCall.args;
@@ -63,7 +63,7 @@ describe('CommerceGraphqlApi', () => {
 
         let query = 'my-sample-query';
 
-        return graphqlApi._fetchGraphql(query, true).then(res => {
+        return graphqlApi._fetchGraphql(query).then(res => {
             // Verify requests
             assert.isTrue(fetchSpy.calledOnce);
             let fetchArguments = fetchSpy.firstCall.args;


### PR DESCRIPTION
## Description

* Updated `_fetchGraphql` method to support cached GraphQL requests by using HTTP GET requests and passing the query as query parameter and un-cached requests via HTTP POST.
* Added unit tests for `CommerceGraphqlApi`.
* This will only work with Magento 2.3.2. Magento 2.3.1 does not support GraphQL requests via HTTP GET.
* Refactored `CommerceGraphqlApi` to use JavaScript modules to be easily unit testable.
* Added `@babel/polyfill` to karma, since it'a a runtime dependency after the webpack build.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
