### PR TITLE
CIF-944 - Update server-side components to use GraphQL caching

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -488,7 +488,7 @@
         <dependency>
             <groupId>com.adobe.commerce.cif</groupId>
             <artifactId>graphql-client</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/MagentoGraphqlClient.java
@@ -90,15 +90,15 @@ public class MagentoGraphqlClient {
     }
 
     /**
-     * Executes the given Magento query and returns the response. This method now uses
-     * by default an HTTP GET request to fetch the data. Use {@link #execute(String, HttpMethod)}
-     * if you want to specify the HTTP method yourself.
+     * Executes the given Magento query and returns the response. This method will use
+     * the default HTTP method defined in the OSGi configuration of the underlying {@link GraphqlClient}.
+     * Use {@link #execute(String, HttpMethod)} if you want to specify the HTTP method yourself.
      * 
      * @param query The GraphQL query.
      * @return The GraphQL response.
      */
     public GraphqlResponse<Query, Error> execute(String query) {
-        return execute(query, HttpMethod.GET);
+        return graphqlClient.execute(new GraphqlRequest(query), Query.class, Error.class, requestOptions);
     }
 
     /**
@@ -110,7 +110,13 @@ public class MagentoGraphqlClient {
      * @return The GraphQL response.
      */
     public GraphqlResponse<Query, Error> execute(String query, HttpMethod httpMethod) {
-        requestOptions.withHttpMethod(httpMethod);
-        return graphqlClient.execute(new GraphqlRequest(query), Query.class, Error.class, requestOptions);
+
+        // We do not set the HTTP method in 'this.requestOptions' to avoid setting it as the new default
+        RequestOptions options = new RequestOptions()
+            .withGson(requestOptions.getGson())
+            .withHeaders(requestOptions.getHeaders())
+            .withHttpMethod(httpMethod);
+
+        return graphqlClient.execute(new GraphqlRequest(query), Query.class, Error.class, options);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/MagentoGraphqlClient.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.adobe.cq.commerce.graphql.client.RequestOptions;
 import com.adobe.cq.commerce.magento.graphql.Query;
 import com.adobe.cq.commerce.magento.graphql.gson.Error;
@@ -89,13 +90,27 @@ public class MagentoGraphqlClient {
     }
 
     /**
-     * Executes the given Magento request and returns the response.
+     * Executes the given Magento query and returns the response. This method now uses
+     * by default an HTTP GET request to fetch the data. Use {@link #execute(String, HttpMethod)}
+     * if you want to specify the HTTP method yourself.
      * 
      * @param query The GraphQL query.
      * @return The GraphQL response.
      */
     public GraphqlResponse<Query, Error> execute(String query) {
-        return graphqlClient.execute(new GraphqlRequest(query), Query.class, Error.class, requestOptions);
+        return execute(query, HttpMethod.GET);
     }
 
+    /**
+     * Executes the given Magento query and returns the response. This method
+     * uses the given <code>httpMethod</code> to fetch the data.
+     * 
+     * @param query The GraphQL query.
+     * @param httpMethod The HTTP method that will be used to fetch the data.
+     * @return The GraphQL response.
+     */
+    public GraphqlResponse<Query, Error> execute(String query, HttpMethod httpMethod) {
+        requestOptions.withHttpMethod(httpMethod);
+        return graphqlClient.execute(new GraphqlRequest(query), Query.class, Error.class, requestOptions);
+    }
 }


### PR DESCRIPTION
- changed default HTTP method to GET when fetching GraphQL data

## Motivation and Context

To support Magento caching, the components will use GET requests.

## How Has This Been Tested?

This has been manually tested. We do not yet have any integration tests that we can use to test the components within AEM.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
