### PR TITLE
CIF-964 - Allow the selection of a product variant in the generic CIF product page URL

### DIFF
--- a/ui.apps/karma.conf.js
+++ b/ui.apps/karma.conf.js
@@ -56,6 +56,10 @@ module.exports = function(config) {
 
     webpack: webpackConfig({ karma: true }),
 
+    webpackMiddleware: {
+      stats: 'errors-only',
+    },
+
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -169,7 +169,7 @@
                     </execution>
                     <execution>
                         <id>npm-webpack-build</id>
-                        <phase>compile</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/README.md
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/README.md
@@ -23,6 +23,7 @@ Product component is a server side component written in HTL, allowing to display
 * Displays product gallery.
 * Displays "add to cart" button to add a simple product or selected variant to the cart.
 * Client-side loaded prices using GraphQL. Can be disabled in the design dialog.
+* Variant selection respects variant SKUs in location hash (e.g. `#variant-a`) and supports the browser history API.
 
 ### Use Object
 The Product component uses the `com.adobe.cq.commerce.core.components.models.product.Product` Sling model as its Use-object.

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/variantSelector.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/variantSelector.js
@@ -46,12 +46,19 @@ class VariantSelector {
         // Update button state on variant change
         this._element.addEventListener(VariantSelector.events.variantChanged, this._updateButtonActiveClass.bind(this));
 
-        // Check for hash and update variant
+        // Check for initial variant sku in hash and listen for url changes
         this._initFromHash();
+        window.addEventListener('popstate', this._initFromHash.bind(this));
     }
 
+    /**
+     * Select variant from the current location hash. This method will update
+     * the internal state and emit a variantchanged event, so all components can
+     * update accordingly.
+     */
     _initFromHash() {
         let sku = window.location.hash.replace('#', '');
+        if (!sku) return;
 
         // Find variant with given sku
         this._state.variant = this._findSelectedVariant(sku);
@@ -59,11 +66,14 @@ class VariantSelector {
         // If variant is valid, store variant attributes and emit event to update
         // buttons and parent components.
         if (this._state.variant) {
-            this._state.attributes = this._state.variant.variantAttributes;
+            this._state.attributes = { ...this._state.variant.variantAttributes };
             this._emitVariantChangedEvent();
         }
     }
 
+    /**
+     * Emit a variantchanged event with a copy of the current component state.
+     */
     _emitVariantChangedEvent() {
         let variantEvent = new CustomEvent(VariantSelector.events.variantChanged, {
             bubbles: true,
@@ -118,6 +128,7 @@ class VariantSelector {
             }
 
             // Iterate variant attributes
+            if (sku) continue;
             for (let key in variant.variantAttributes) {
                 let selectedValue = this._state.attributes[key];
                 match = match && selectedValue == variant.variantAttributes[key];
@@ -161,6 +172,9 @@ class VariantSelector {
         event.preventDefault();
     }
 
+    /**
+     * Set location hash by pushing to the history state.
+     */
     _setHash(sku) {
         history.pushState(null, null, '#' + sku);
     }

--- a/ui.apps/test/components/commerce/product/variantSelectorTest.js
+++ b/ui.apps/test/components/commerce/product/variantSelectorTest.js
@@ -50,6 +50,10 @@ describe('Product', () => {
             );
         });
 
+        afterEach(() => {
+            window.location.hash = '';
+        });
+
         it('initializes a variantselector component', () => {
             let selector = new VariantSelector({ element: selectorRoot });
 
@@ -57,7 +61,7 @@ describe('Product', () => {
             assert.equal(selector._state.buttons.length, 2);
         });
 
-        it('initializes from a window location hash', () => {
+        it('initializes variant from a window location hash', () => {
             window.location.hash = '#red';
 
             let selector = new VariantSelector({ element: selectorRoot });
@@ -65,12 +69,27 @@ describe('Product', () => {
             assert.equal(selector._state.variant.sku, 'red');
         });
 
-        it('returns the selected variant', () => {
+        it('initializes base product for invalid window location hash', () => {
+            window.location.hash = '#purple';
+
+            let selector = new VariantSelector({ element: selectorRoot });
+
+            assert.isNull(selector._state.variant);
+        });
+
+        it('returns the selected variant based on attributes', () => {
             let selector = new VariantSelector({ element: selectorRoot });
             selector._state.attributes['color'] = 'red';
 
             let selectedVariant = selector._findSelectedVariant();
             assert.equal(selectedVariant.name, variantData[0].name);
+        });
+
+        it('returns the selected variant based on sku', () => {
+            let selector = new VariantSelector({ element: selectorRoot });
+
+            let selectedVariant = selector._findSelectedVariant('blue');
+            assert.equal(selectedVariant.name, variantData[1].name);
         });
 
         it('returns null if no variant can be found', () => {

--- a/ui.apps/test/components/commerce/product/variantSelectorTest.js
+++ b/ui.apps/test/components/commerce/product/variantSelectorTest.js
@@ -21,12 +21,14 @@ describe('Product', () => {
         let variantData = [
             {
                 name: 'Red Jeans',
+                sku: 'red',
                 variantAttributes: {
                     color: 'red'
                 }
             },
             {
                 name: 'Blue Jeans',
+                sku: 'blue',
                 variantAttributes: {
                     color: 'blue'
                 }
@@ -53,6 +55,14 @@ describe('Product', () => {
 
             assert.deepEqual(selector._state.variantData, variantData);
             assert.equal(selector._state.buttons.length, 2);
+        });
+
+        it('initializes from a window location hash', () => {
+            window.location.hash = '#red';
+
+            let selector = new VariantSelector({ element: selectorRoot });
+
+            assert.equal(selector._state.variant.sku, 'red');
         });
 
         it('returns the selected variant', () => {
@@ -83,6 +93,19 @@ describe('Product', () => {
             });
 
             assert.isTrue(spy.called);
+        });
+
+        it('updates the window location hash on changing the variant', () => {
+            let selector = new VariantSelector({ element: selectorRoot });
+
+            // Simulate button click
+            selector._onSelectVariant({
+                target: selectorRoot.querySelector("[data-id='red']"),
+                preventDefault: () => {}
+            });
+
+            // Verify location hash
+            assert.equal(window.location.hash, '#red');
         });
 
         it('updates swatch button on receiving a variantchanged event', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Product component (variant selector) now respects variant SKUs in the location hash and displays the correct variant accordingly
* Product component (variant selector) sets the SKU of the currently selected variant in the location hash
* Using the `history` API, it is possible to go back to previously selected variants using the browser's back button.
* Remove webpack info output from karma test runner
* Fix Maven phase of webpack execution

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
