### PR TITLE
CIF-994 - The sample Magento proxy config doesn't support SSL

### DIFF
--- a/dispatcher/conf/magento-proxy.conf
+++ b/dispatcher/conf/magento-proxy.conf
@@ -12,10 +12,14 @@
 #
 ################################################################################
 
+# If the Magento URL is on HTTPS we need to enable SSL
+SSLProxyEngine on
+LoadModule ssl_module modules/mod_ssl.so
+
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_connect_module modules/mod_proxy_connect.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
-
+ 
 Define magento_host http://my-magento.cloud
 
 ProxyPass "/magento/graphql" "${magento_host}/graphql"


### PR DESCRIPTION
Add the required configuration to the `magento-proxy` configuration file.

## Description

`mod-ssl` and SSLProxyEngine have to be configured so that the proxy allows connections via HTTPS

## Related Issue

CIF-994

## Motivation and Context

Connection via HTTPS to the Magento backend

## How Has This Been Tested?

Functional testing.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
