### PR TITLE
CIF-991 - MagentoGraphqlClient & Utils should be public

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -496,7 +496,7 @@
         <dependency>
             <groupId>com.adobe.commerce.cif</groupId>
             <artifactId>magento-graphql</artifactId>
-            <version>3.0.0-magento232</version>
+            <version>3.0.1-magento232</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-package com.adobe.cq.commerce.core.components.internal.models.v1;
+package com.adobe.cq.commerce.core.components.client;
 
 import java.util.Collections;
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/Utils.java
@@ -18,28 +18,12 @@ import java.text.NumberFormat;
 import java.util.Currency;
 import java.util.Locale;
 
-import javax.annotation.Nullable;
-
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
-import com.day.cq.commons.inherit.InheritanceValueMap;
-import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
-
 public class Utils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
-    private static final String PN_CIF_CATEGORY_PAGE = "cq:cifCategoryPage";
-    private static final String PN_CIF_PRODUCT_PAGE = "cq:cifProductPage";
-    private static final String PN_CIF_SEARCH_RESULTS_PAGE = "cq:cifSearchResultsPage";
-    /**
-     * Boolean property to mark the navigation root page.
-     */
-    static final String PN_NAV_ROOT = "navRoot";
 
-    private Utils() {}
+    private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
 
     /**
      * Builds a NumberFormat instance used for formatting prices based on the given
@@ -63,83 +47,4 @@ public class Utils {
 
         return formatter;
     }
-
-    /**
-     * Retrieves the generic product page based on the current page or current page ancestors
-     * using the page path configured via cq:cifProductPage property.
-     *
-     * @param page the current page
-     * @return the generic product template page
-     */
-    public static Page getProductPage(Page page) {
-        return getGenericPage(PN_CIF_PRODUCT_PAGE, page);
-    }
-
-    /**
-     * Retrieves the generic category page based on a page or page ancestors using the page path configured
-     * via cq:cifCategoryPage property.
-     *
-     * @param page the page for looking up the property
-     * @return the generic category template page
-     */
-    @Nullable
-    public static Page getCategoryPage(Page page) {
-        return getGenericPage(PN_CIF_CATEGORY_PAGE, page);
-    }
-
-    @Nullable
-    public static Page getSearchResultsPage(Page page) {
-        return getGenericPage(PN_CIF_SEARCH_RESULTS_PAGE, page);
-    }
-
-    /**
-     * Retrieves the navigation root related to the specified page.
-     * The page and its parents is searched for the navRoot=true property, marking the navigation root.
-     *
-     * @param page the page
-     *
-     * @return the navigation root page if found, otherwise {@code null}
-     */
-    @Nullable
-    public static Page getNavigationRootPage(Page page) {
-        while (page != null) {
-            if (page.getContentResource().getValueMap().get(PN_NAV_ROOT, false)) {
-                break;
-            }
-
-            page = page.getParent();
-        }
-        return page;
-    }
-
-    /**
-     * Retrieves a generic page based on a page or page ancestors using the page path configured
-     * via the property of the root page.
-     *
-     * @param pageTypeProperty The name of the JCR property on the root page that points to the generic page
-     * @param page the page for looking up the property
-     * @return the generic page
-     */
-    @Nullable
-    private static Page getGenericPage(String pageTypeProperty, Page page) {
-        final InheritanceValueMap properties = new HierarchyNodeInheritanceValueMap(page.getContentResource());
-        String utilityPagePath = properties.getInherited(pageTypeProperty, String.class);
-        if (StringUtils.isBlank(utilityPagePath)) {
-            LOGGER.warn("Page property {} not found at {}", pageTypeProperty, page.getPath());
-            return null;
-        }
-
-        PageManager pageManager = page.getPageManager();
-        Page categoryPage = pageManager.getPage(utilityPagePath);
-        if (categoryPage == null) {
-            LOGGER.warn("No page found at {}", utilityPagePath);
-            return null;
-        }
-        return categoryPage;
-    }
-
-    public static String constructUrlfromSlug(String pagePath, String slug) {
-        return String.format("%s.%s.html", pagePath, slug);
-    }
-
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/button/ButtonImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/button/ButtonImpl.java
@@ -30,7 +30,7 @@ import org.apache.sling.models.annotations.via.ResourceSuperType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.wcm.core.components.models.Button;
 import com.day.cq.wcm.api.Page;
 
@@ -104,7 +104,7 @@ public class ButtonImpl implements Button {
             case PRODUCT: {
 
                 if (!productSlug.equals(DEFAULT_LINK)) {
-                    productPage = Utils.getProductPage(currentPage);
+                    productPage = SiteNavigation.getProductPage(currentPage);
                     if (productPage == null) {
                         productPage = currentPage;
                     }
@@ -117,7 +117,7 @@ public class ButtonImpl implements Button {
             case CATEGORY: {
 
                 if (!categoryId.equals(DEFAULT_LINK)) {
-                    categoryPage = Utils.getCategoryPage(currentPage);
+                    categoryPage = SiteNavigation.getCategoryPage(currentPage);
                     if (categoryPage == null) {
                         categoryPage = currentPage;
                     }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCateogoryListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCateogoryListImpl.java
@@ -31,9 +31,9 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.models.categorylist.FeaturedCategoryList;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.*;
 import com.adobe.cq.commerce.magento.graphql.gson.Error;
@@ -66,7 +66,7 @@ public class FeaturedCateogoryListImpl implements FeaturedCategoryList {
 
     @PostConstruct
     private void initModel() {
-        categoryPage = Utils.getCategoryPage(currentPage);
+        categoryPage = SiteNavigation.getCategoryPage(currentPage);
         if (categoryPage == null) {
             categoryPage = currentPage;
         }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/header/HeaderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/header/HeaderImpl.java
@@ -24,8 +24,8 @@ import org.apache.sling.models.annotations.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
 import com.adobe.cq.commerce.core.components.models.header.Header;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.day.cq.wcm.api.Page;
 
 /**
@@ -55,7 +55,7 @@ public class HeaderImpl implements Header {
     @Override
     public String getNavigationRootPageUrl() {
         if (navigationRootPage == null) {
-            navigationRootPage = Utils.getNavigationRootPage(currentPage);
+            navigationRootPage = SiteNavigation.getNavigationRootPage(currentPage);
         }
 
         if (navigationRootPage == null) {

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
 import com.adobe.cq.commerce.magento.graphql.CategoryTreeQuery;

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
@@ -32,9 +32,9 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
 import com.adobe.cq.commerce.core.components.models.navigation.Navigation;
 import com.adobe.cq.commerce.core.components.models.navigation.NavigationItem;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
 import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
 import com.day.cq.commons.inherit.InheritanceValueMap;
@@ -133,7 +133,7 @@ public class NavigationImpl implements Navigation {
     }
 
     private void expandCatalogRoot(Page catalogPage, List<NavigationItem> pages) {
-        Page categoryPage = Utils.getCategoryPage(currentPage);
+        Page categoryPage = SiteNavigation.getCategoryPage(currentPage);
         if (categoryPage == null) {
             return;
         }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
@@ -35,7 +35,7 @@ import org.apache.sling.xss.XSSAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
 import com.adobe.cq.commerce.core.components.models.product.Asset;
 import com.adobe.cq.commerce.core.components.models.product.Product;

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
@@ -30,11 +30,11 @@ import org.apache.sling.models.annotations.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.internal.models.v1.productlist.ProductListItemImpl;
 import com.adobe.cq.commerce.core.components.models.productcarousel.ProductCarousel;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductListItem;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.FilterTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Operations;
@@ -72,7 +72,7 @@ public class ProductCarouselImpl implements ProductCarousel {
     private void initModel() {
         final List<String> productSkus = Arrays.asList(this.productSkuList);
         magentoGraphqlClient = MagentoGraphqlClient.create(resource);
-        productPage = Utils.getProductPage(currentPage);
+        productPage = SiteNavigation.getProductPage(currentPage);
         if (productPage == null) {
             productPage = currentPage;
         }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
@@ -32,10 +32,10 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductList;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductListItem;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.*;
 import com.adobe.cq.commerce.magento.graphql.gson.Error;
@@ -96,7 +96,7 @@ public class ProductListImpl implements ProductList {
         setNavPageCursor();
 
         // get product template page
-        productPage = Utils.getProductPage(currentPage);
+        productPage = SiteNavigation.getProductPage(currentPage);
         if (productPage == null) {
             productPage = currentPage;
         }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListItemImpl.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 
 import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductListItem;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.day.cq.wcm.api.Page;
 
 public class ProductListItemImpl implements ProductListItem {
@@ -70,7 +71,7 @@ public class ProductListItemImpl implements ProductListItem {
     @Nullable
     @Override
     public String getURL() {
-        return Utils.constructUrlfromSlug(productPage.getPath(), this.getSlug());
+        return SiteNavigation.toProductUrl(productPage.getPath(), this.getSlug());
     }
 
     @Nullable

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
@@ -30,9 +30,10 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
 import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.FilterTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Operations;
@@ -68,7 +69,7 @@ public class ProductTeaserImpl implements ProductTeaser {
 
     @PostConstruct
     private void initModel() {
-        productPage = Utils.getProductPage(currentPage);
+        productPage = SiteNavigation.getProductPage(currentPage);
         if (productPage == null) {
             productPage = currentPage;
         }
@@ -105,7 +106,7 @@ public class ProductTeaserImpl implements ProductTeaser {
 
     @Override
     public String getUrl() {
-        return (product != null ? Utils.constructUrlfromSlug(productPage.getPath(), product.getUrlKey()) : null);
+        return (product != null ? SiteNavigation.toProductUrl(productPage.getPath(), product.getUrlKey()) : null);
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/searchbar/SearchbarImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/searchbar/SearchbarImpl.java
@@ -21,8 +21,8 @@ import javax.inject.Inject;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
 import com.adobe.cq.commerce.core.components.models.searchbar.Searchbar;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.day.cq.wcm.api.Page;
 
 /**
@@ -45,7 +45,7 @@ public class SearchbarImpl implements Searchbar {
     @Override
     public String getSearchResultsPageUrl() {
         if (searchResultsPage == null) {
-            searchResultsPage = Utils.getSearchResultsPage(currentPage);
+            searchResultsPage = SiteNavigation.getSearchResultsPage(currentPage);
         }
 
         return searchResultsPage.getPath() + ".html";

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/searchresults/SearchResultsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/searchresults/SearchResultsImpl.java
@@ -32,11 +32,11 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.internal.models.v1.productlist.ProductListItemImpl;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductListItem;
 import com.adobe.cq.commerce.core.components.models.searchresults.SearchResults;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.FilterTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Operations;
@@ -85,7 +85,7 @@ public class SearchResultsImpl implements SearchResults {
 
         // Get MagentoGraphqlClient from the resource.
         magentoGraphqlClient = MagentoGraphqlClient.create(resource);
-        productPage = Utils.getProductPage(currentPage);
+        productPage = SiteNavigation.getProductPage(currentPage);
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserActionItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserActionItem.java
@@ -17,7 +17,7 @@ package com.adobe.cq.commerce.core.components.internal.models.v1.teaser;
 
 import javax.annotation.Nonnull;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.day.cq.wcm.api.Page;
 
@@ -43,6 +43,6 @@ public class CommerceTeaserActionItem implements ListItem {
     @Override
     public String getURL() {
         return (selector == null || selector.trim().equalsIgnoreCase("")) ? (page.getPath() + ".html")
-            : Utils.constructUrlfromSlug(page.getPath(), selector);
+            : SiteNavigation.toProductUrl(page.getPath(), selector);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserImpl.java
@@ -29,8 +29,8 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.Utils;
 import com.adobe.cq.commerce.core.components.models.teaser.CommerceTeaser;
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.day.cq.wcm.api.Page;
 
@@ -58,8 +58,8 @@ public class CommerceTeaserImpl implements CommerceTeaser {
     @PostConstruct
     void initModel() {
         setActionsEnabled();
-        productPage = Utils.getProductPage(currentPage);
-        categoryPage = Utils.getCategoryPage(currentPage);
+        productPage = SiteNavigation.getProductPage(currentPage);
+        categoryPage = SiteNavigation.getCategoryPage(currentPage);
 
         if (actionsEnabled) {
             populateActions();

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/utils/SiteNavigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/utils/SiteNavigation.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.core.components.utils;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
+import com.day.cq.commons.inherit.InheritanceValueMap;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+
+public class SiteNavigation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SiteNavigation.class);
+    private static final String PN_CIF_CATEGORY_PAGE = "cq:cifCategoryPage";
+    private static final String PN_CIF_PRODUCT_PAGE = "cq:cifProductPage";
+    private static final String PN_CIF_SEARCH_RESULTS_PAGE = "cq:cifSearchResultsPage";
+
+    /**
+     * Boolean property to mark the navigation root page.
+     */
+    static final String PN_NAV_ROOT = "navRoot";
+
+    private SiteNavigation() {}
+
+    /**
+     * Retrieves the generic product page based on the current page or current page ancestors
+     * using the page path configured via cq:cifProductPage property.
+     *
+     * @param page the current page
+     * @return the generic product template page
+     */
+    public static Page getProductPage(Page page) {
+        return getGenericPage(PN_CIF_PRODUCT_PAGE, page);
+    }
+
+    /**
+     * Retrieves the generic category page based on a page or page ancestors using the page path configured
+     * via cq:cifCategoryPage property.
+     *
+     * @param page the page for looking up the property
+     * @return the generic category template page
+     */
+    @Nullable
+    public static Page getCategoryPage(Page page) {
+        return getGenericPage(PN_CIF_CATEGORY_PAGE, page);
+    }
+
+    /**
+     * Retrieves the generic search page based on a page or page ancestors using the page path configured
+     * via cq:cifSearchResultsPage property.
+     *
+     * @param page the page for looking up the property
+     * @return the search results template page
+     */
+    @Nullable
+    public static Page getSearchResultsPage(Page page) {
+        return getGenericPage(PN_CIF_SEARCH_RESULTS_PAGE, page);
+    }
+
+    /**
+     * Retrieves the navigation root related to the specified page.
+     * The page and its parents is searched for the navRoot=true property, marking the navigation root.
+     *
+     * @param page the page
+     *
+     * @return the navigation root page if found, otherwise {@code null}
+     */
+    @Nullable
+    public static Page getNavigationRootPage(Page page) {
+        while (page != null) {
+            if (page.getContentResource().getValueMap().get(PN_NAV_ROOT, false)) {
+                break;
+            }
+
+            page = page.getParent();
+        }
+        return page;
+    }
+
+    /**
+     * Retrieves a generic page based on a page or page ancestors using the page path configured
+     * via the property of the root page.
+     *
+     * @param pageTypeProperty The name of the JCR property on the root page that points to the generic page
+     * @param page the page for looking up the property
+     * @return the generic page
+     */
+    @Nullable
+    private static Page getGenericPage(String pageTypeProperty, Page page) {
+        final InheritanceValueMap properties = new HierarchyNodeInheritanceValueMap(page.getContentResource());
+        String utilityPagePath = properties.getInherited(pageTypeProperty, String.class);
+        if (StringUtils.isBlank(utilityPagePath)) {
+            LOGGER.warn("Page property {} not found at {}", pageTypeProperty, page.getPath());
+            return null;
+        }
+
+        PageManager pageManager = page.getPageManager();
+        Page categoryPage = pageManager.getPage(utilityPagePath);
+        if (categoryPage == null) {
+            LOGGER.warn("No page found at {}", utilityPagePath);
+            return null;
+        }
+        return categoryPage;
+    }
+
+    /**
+     * Builds and returns a product page URL based on the given page path and slug.
+     * 
+     * @param pagePath The base page path for the URL.
+     * @param slug The slug of the product.
+     * @return The product page URL.
+     */
+    public static String toProductUrl(String pagePath, String slug) {
+        return String.format("%s.%s.html", pagePath, slug);
+    }
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/MagentoGraphqlClientTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/MagentoGraphqlClientTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.adobe.cq.commerce.graphql.client.RequestOptions;

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.MagentoGraphqlClient;
+import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
 import com.adobe.cq.commerce.magento.graphql.Operations;

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/utils/SiteNavigationTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/utils/SiteNavigationTest.java
@@ -13,7 +13,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-package com.adobe.cq.commerce.core.components.internal.models.v1;
+package com.adobe.cq.commerce.core.components.utils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,17 +24,18 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.day.cq.wcm.api.Page;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class UtilsTest {
+public class SiteNavigationTest {
 
     @Test
     public void testGetNavigationRootPage() {
         Map<String, Object> properties = new HashMap<>();
-        properties.put(Utils.PN_NAV_ROOT, true);
+        properties.put(SiteNavigation.PN_NAV_ROOT, true);
         Page navRootPage = mockPage(properties);
         Page page0 = mockPage(null);
         Page page1 = mockPage(null);
@@ -45,22 +46,22 @@ public class UtilsTest {
         when(page2.getParent()).thenReturn(page3);
 
         // returns null for null
-        Assert.assertNull(Utils.getNavigationRootPage(null));
+        Assert.assertNull(SiteNavigation.getNavigationRootPage(null));
 
         // returns navigation root for navigation root
-        Assert.assertSame(navRootPage, Utils.getNavigationRootPage(navRootPage));
+        Assert.assertSame(navRootPage, SiteNavigation.getNavigationRootPage(navRootPage));
 
         // returns navigation root for navigation root child
-        Assert.assertSame(navRootPage, Utils.getNavigationRootPage(page1));
+        Assert.assertSame(navRootPage, SiteNavigation.getNavigationRootPage(page1));
 
         // returns navigation root for child of navigation root child
-        Assert.assertSame(navRootPage, Utils.getNavigationRootPage(page0));
+        Assert.assertSame(navRootPage, SiteNavigation.getNavigationRootPage(page0));
 
         // returns null for page with no parent
-        Assert.assertNull(Utils.getNavigationRootPage(page3));
+        Assert.assertNull(SiteNavigation.getNavigationRootPage(page3));
 
         // returns null for page with no navigation root parent
-        Assert.assertNull(Utils.getNavigationRootPage(page2));
+        Assert.assertNull(SiteNavigation.getNavigationRootPage(page2));
     }
 
     private static Page mockPage(Map<String, Object> contentProperties) {

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/utils/SiteNavigationTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/utils/SiteNavigationTest.java
@@ -24,7 +24,6 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.day.cq.wcm.api.Page;
 
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
- moved `MagentoGraphqlClient` to a new (exported) package `com.adobe.cq.commerce.core.components.client`
- moved all navigation related methods from `Utils` to a new (exported) package and class `com.adobe.cq.commerce.core.components.utils.SiteNavigation`
- left the method `buildPriceFormatter` in the existing `Utils` class ... I'm not sure we also want to export it

Let me know what you think or provide alternatives if you don't like the new classes and packages names.