### PR TITLE
CIF-1044 - Page becomes unresponsive in author instance on localhost

### DIFF
--- a/ui.apps/src/main/javascript/minicart/src/utils/hooks.js
+++ b/ui.apps/src/main/javascript/minicart/src/utils/hooks.js
@@ -48,18 +48,21 @@ export const useGuestCart = () => {
     const cookieName = 'cif.cart';
     const [reset, doReset] = useState(false);
     let [cartId, setCartCookie] = useCookieValue(cookieName);
-    const [createCart, { data }] = useMutation(MUTATION_CREATE_CART);
+    const [createCart, { data, error }] = useMutation(MUTATION_CREATE_CART);
+
+    if (!cartId || cartId.length === 0) {
+        createCart();
+    }
 
     useEffect(() => {
-        if (!cartId || cartId.length === 0) {
-            createCart();
-
-            if (data) {
-                cartId = data.createEmptyCart;
-                setCartCookie(cartId);
-            }
+        if (data) {
+            cartId = data.createEmptyCart;
+            setCartCookie(cartId);
         }
-    });
+        if (error) {
+            console.error(error);
+        }
+    }, [data, error]);
 
     const resetGuestCart = useCallback(() => {
         setCartCookie('', 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The problem was caused by the poor implementation of the `useGuestCart` hook. The hook was retrying the query if it failed the first time, and it did so indefinitely.

Moving the `createCart` call outside the `useEffect` hook fixed the issue.

## Related Issue

CIF-1044
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Using the Venia storefront in author more caused the browser to become unresponsive.
 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
