### PR TITLE
CIF-1048 - Make PDP template fully author-able

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/.content.xml
@@ -4,6 +4,6 @@
           xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
           jcr:primaryType="cq:Component"
-          jcr:title="AEM CIF Product"
-          componentGroup=".hidden">
+          jcr:title="Product Detail"
+          componentGroup="CIF Core Components">
 </jcr:root>


### PR DESCRIPTION
##  Description

Make product detail component visible for authors as part of making the PDP fully author-able. Also see CIF archetype PR https://github.com/adobe/aem-cif-project-archetype/pull/44

## Related Issue

CIF-1048 & https://github.com/adobe/aem-cif-project-archetype/issues/38

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Screenshot 2019-10-02 at 14 20 34](https://user-images.githubusercontent.com/2643450/66044655-5a692600-e522-11e9-9550-1db749c3d6d8.png)
Product detail component in AEM editor with full authoring tooling available.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
