### PR TITLE
CIF-1049 - Make PLP template fully author-able

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/.content.xml
@@ -3,6 +3,6 @@
           xmlns:cq="http://www.day.com/jcr/cq/1.0"
           xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="cq:Component"
-          componentGroup=".hidden"
+          componentGroup="CIF Core Components"
           jcr:title="Product List">
 </jcr:root>


### PR DESCRIPTION
##  Description

Make product list component visible for authors as part of making the PLP/category page fully author-able. Also see CIF archetype PR https://github.com/adobe/aem-cif-project-archetype/pull/45 which contains the bigger part of this change

## Related Issue

CIF-1049 & https://github.com/adobe/aem-cif-project-archetype/issues/38

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Screenshot 2019-10-04 at 12 33 46](https://user-images.githubusercontent.com/2643450/66201259-3d0f9580-e6a3-11e9-944f-f7dd7a051771.png)
Product list component in AEM editor with full authoring tooling available.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
