### PR TITLE
CIF-1078 - Signing out of the demo store doesn't revoke the customer token

### DIFF
--- a/ui.apps/src/main/javascript/minicart/src/context/UserContext.js
+++ b/ui.apps/src/main/javascript/minicart/src/context/UserContext.js
@@ -34,9 +34,9 @@ const parseError = error => {
 };
 
 const UserContextProvider = props => {
-    const [userToken, setUserToken] = useCookieValue('cif.userToken');
-    const [token, setToken] = useState(userToken);
-    const isSignedIn = () => !!userToken;
+    const [userCookie, setUserCookie] = useCookieValue('cif.userToken');
+    const [token, setToken] = useState(userCookie);
+    const isSignedIn = () => !!userCookie;
 
     const initialState = {
         currentUser: {
@@ -77,16 +77,21 @@ const UserContextProvider = props => {
 
     // if we have customer data (i.e. the getCustomerDetails query returned something) set it in the state
     useEffect(() => {
-        if (customerData && customerData.customer && !customerDetailsError) {
+        if (customerData && customerData.customer) {
             const { firstname, lastname, email } = customerData.customer;
             setUserState({ ...userState, currentUser: { firstname, lastname, email } });
+        }
+        if (customerDetailsError) {
+            setUserState({ ...userState, isSignedIn: false });
+            setToken('');
+            setUserCookie('', 0);
         }
     }, [customerData, customerDetailsError, customerDetailsLoading]);
 
     // if the signin mutation returned something handle the response
     useEffect(() => {
         if (data && data.generateCustomerToken && !error) {
-            setUserToken(data.generateCustomerToken.token);
+            setUserCookie(data.generateCustomerToken.token);
             setToken(data.generateCustomerToken.token);
             setUserState({ ...userState, isSignedIn: true });
         }
@@ -95,7 +100,7 @@ const UserContextProvider = props => {
     useEffect(() => {
         if (revokeTokenData && revokeTokenData.revokeCustomerToken && revokeTokenData.revokeCustomerToken.result) {
             setToken('');
-            setUserToken('', 0);
+            setUserCookie('', 0);
             setUserState({ ...userState, isSignedIn: false });
         }
         if (revokeTokenError) {

--- a/ui.apps/src/main/javascript/minicart/src/context/__test__/UserContext.test.js
+++ b/ui.apps/src/main/javascript/minicart/src/context/__test__/UserContext.test.js
@@ -17,6 +17,7 @@ import { MockedProvider } from '@apollo/react-testing';
 
 import MUTATION_GENERATE_TOKEN from '../../queries/mutation_generate_token.graphql';
 import QUERY_CUSTOMER_DETAILS from '../../queries/query_customer_details.graphql';
+import MUTATION_REVOKE_TOKEN from '../../queries/mutation_revoke_customer_token.graphql';
 
 import UserContextProvider, { useUserContext } from '../UserContext';
 
@@ -44,6 +45,18 @@ describe('UserContext test', () => {
                         email: 'test@example.com',
                         firstname: 'John',
                         lastname: 'Doe'
+                    }
+                }
+            }
+        },
+        {
+            request: {
+                query: MUTATION_REVOKE_TOKEN
+            },
+            result: {
+                data: {
+                    revokeCustomerToken: {
+                        result: true
                     }
                 }
             }
@@ -118,5 +131,10 @@ describe('UserContext test', () => {
 
         const result = await waitForElement(() => getByTestId('success'));
         expect(result).not.toBeUndefined();
+
+        // normally the browser just removes a cookie with Max-Age=0
+        //...but we're not in a browser
+        const expectedCookieValue = 'cif.userToken=;path=/; domain=localhost;Max-Age=0';
+        expect(document.cookie).toEqual(expectedCookieValue);
     });
 });

--- a/ui.apps/src/main/javascript/minicart/src/queries/mutation_revoke_customer_token.graphql
+++ b/ui.apps/src/main/javascript/minicart/src/queries/mutation_revoke_customer_token.graphql
@@ -1,0 +1,5 @@
+mutation {
+    revokeCustomerToken {
+        result
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

* Call the `revokeCustomerToken` mutation when signing out.
* Fix a bug which was causing the cookie not to be removed, but set to an empty value instead.
* Update unit tests

<!--- Describe your changes in detail -->

## Related Issue

CIF-1078

## Motivation and Context

Security risk: the customer token cookie was removed but it wasn't revoked server-side, so anyone who made a copy of that cookie could issue queries using the token in the authorization header.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Functional testing, update unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
