### PR TITLE
CIF-1058 - Cart/Checkout do not respect multi store hierarchy configuration

### DIFF
--- a/ui.apps/src/main/javascript/minicart/src/index.js
+++ b/ui.apps/src/main/javascript/minicart/src/index.js
@@ -25,12 +25,11 @@ import { CheckoutProvider, initialState as initialCheckoutState, reducer } from 
 import AuthBar from './components/AuthBar';
 
 const App = () => {
-
     const storeView = document.querySelector('body').dataset.storeView || 'default';
 
     const client = new ApolloClient({
         uri: '/magento/graphql',
-        headers: { 'Store': storeView }
+        headers: { Store: storeView }
     });
 
     return (

--- a/ui.apps/src/main/javascript/minicart/src/index.js
+++ b/ui.apps/src/main/javascript/minicart/src/index.js
@@ -25,8 +25,12 @@ import { CheckoutProvider, initialState as initialCheckoutState, reducer } from 
 import AuthBar from './components/AuthBar';
 
 const App = () => {
+
+    const storeView = document.querySelector('body').dataset.storeView || 'default';
+
     const client = new ApolloClient({
-        uri: '/magento/graphql'
+        uri: '/magento/graphql',
+        headers: { 'Store': storeView }
     });
 
     return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Similar to https://github.com/adobe/aem-core-cif-components/pull/131 the React components that use the Apollo client to send GraphQL requests now respect the `cq:magentoStore` property to include a `Store` header in the requests.

## Verification
1. Add a product to the cart. Verify that the client-side GraphQL requests (both for adding the product and retrieving the cart) contain a `Store: default` header.
2. Configure the website to use a different storeview, e.g. `venia`. You can do that by setting the `cq:magentoStore` property on a page. Repeat step 1 and verify that the header has changed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
