### PR TITLE
CIF-1108 - Update WCM core components dependency to 2.7.0

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -482,7 +482,6 @@
             <artifactId>core.wcm.components.core</artifactId>
             <scope>provided</scope>
             <version>2.5.0</version>
-            
         </dependency>
 
         <!-- CIF Dependencies -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -913,7 +913,7 @@
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.core</artifactId>
-                <version>2.5.0</version>
+                <version>2.7.0</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
See https://github.com/adobe/aem-cif-project-archetype/pull/54.