### PR TITLE
CIF-1105 - Unneeded rootPath attribute in component edit dialogs

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/_cq_dialog/.content.xml
@@ -23,7 +23,6 @@
                             fieldLabel="Product"
                             filter="folderOrProductOrVariant"
                             name="./product"
-                            rootPath="/var/commerce/products"
                             selectionId="combinedSku"/>
                     </content>
                 </items>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/button/v1/button/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/button/v1/button/_cq_dialog/.content.xml
@@ -103,7 +103,6 @@
                                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                                 fieldLabel="Product"
                                                                 name="./productSlug"
-                                                                rootPath="/var/commerce/products"
                                                                 selectionId="slug"/>
                                                         </items>
                                                     </well>
@@ -126,7 +125,6 @@
                                                                 sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                                                                 fieldLabel="Category"
                                                                 name="./categoryId"
-                                                                rootPath="/var/commerce/products"
                                                                 selectionId="id"/>
                                                         </items>
                                                     </well>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -82,12 +82,12 @@
                                                         <link
                                                             granite:class="cmp-teaser__editor-actionField"
                                                             jcr:primaryType="nt:unstructured"
+                                                            sling:hideProperties="rootPath"
                                                             sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                             emptyText="Product"
                                                             fieldLabel="Product Page"
                                                             name="productSlug"
                                                             required="{Boolean}false"
-                                                            rootPath="/var/commerce/products"
                                                             selectionId="slug">
                                                             <granite:data
                                                                 jcr:primaryType="nt:unstructured"
@@ -100,8 +100,7 @@
                                                             emptyText="Category"
                                                             fieldLabel="Category Page"
                                                             name="categoryId"
-                                                            required="{Boolean}false"
-                                                            rootPath="/var/commerce/products">
+                                                            required="{Boolean}false">
                                                             <granite:data
                                                                 jcr:primaryType="nt:unstructured"
                                                                 cmp-teaser-v1-dialog-edit-hook="actionLink"/>


### PR DESCRIPTION
- removed rootPath property in components with product picker
- hide rootPath property from parent component for the content teaser

## How Has This Been Tested?

Manually tested with product carousel, teaser, and button component.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
