### PR TITLE
CIF-1175 - Call-to-action button for product teaser

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
@@ -58,7 +58,6 @@ public class ProductTeaserImpl implements ProductTeaser {
     private NumberFormat priceFormatter;
     private Page productPage;
     private Pair<String, String> combinedSku;
-
     private AbstractProductRetriever productRetriever;
 
     @PostConstruct
@@ -104,7 +103,8 @@ public class ProductTeaserImpl implements ProductTeaser {
 
     @Override
     public String getSku() {
-        return getProduct().getSku();
+        String sku = getProduct().getSku();
+        return sku != null ? sku : combinedSku.getLeft();
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
@@ -103,6 +103,16 @@ public class ProductTeaserImpl implements ProductTeaser {
     }
 
     @Override
+    public String getSku() {
+        return getProduct().getSku();
+    }
+
+    @Override
+    public String getCallToAction() {
+        return properties.get("cta", null);
+    }
+
+    @Override
     public String getFormattedPrice() {
         Double price = getPrice();
         if (price != null) {

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/productteaser/ProductTeaser.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/productteaser/ProductTeaser.java
@@ -53,6 +53,21 @@ public interface ProductTeaser {
     String getUrl();
 
     /**
+     * Returns the SKU of the product displayed by this {@code ProductTeaser}
+     * 
+     * @return a String value representing the SKU
+     */
+    String getSku();
+
+    /**
+     * Returns the "call to action" configured for this teaser.
+     * 
+     * @return the value of the "call to action" option. This can be "add-to-cart" or "details". If no CTA is configured then this methods
+     *         returns {@link null}
+     */
+    String getCallToAction();
+
+    /**
      * Returns in instance of the product retriever for fetching product data via GraphQL.
      *
      * @return product retriever instance

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImplTest.java
@@ -54,7 +54,7 @@ public class ProductTeaserImplTest {
         return new AemContext((AemContextCallback) context -> {
             // Load page structure
             context.load()
-                   .json(contentPath, "/content");
+                .json(contentPath, "/content");
         }, ResourceResolverType.JCR_MOCK);
     }
 
@@ -76,32 +76,32 @@ public class ProductTeaserImplTest {
         Page page = context.currentPage(PAGE);
         context.currentResource(resourcePath);
         teaserResource = Mockito.spy(context.resourceResolver()
-                                            .getResource(resourcePath));
+            .getResource(resourcePath));
 
         String json = getResource("/graphql/magento-graphql-productteaser-result.json");
         Query rootQuery = QueryDeserializer.getGson()
-                                           .fromJson(json, Query.class);
+            .fromJson(json, Query.class);
         product = rootQuery.getProducts()
-                           .getItems()
-                           .get(0);
+            .getItems()
+            .get(0);
 
         GraphqlResponse<Object, Object> response = new GraphqlResponse<>();
         response.setData(rootQuery);
         GraphqlClient graphqlClient = Mockito.mock(GraphqlClient.class);
         Mockito.when(teaserResource.adaptTo(GraphqlClient.class))
-               .thenReturn(graphqlClient);
+            .thenReturn(graphqlClient);
         Mockito.when(graphqlClient.execute(any(), any(), any(), any()))
-               .thenReturn(response);
+            .thenReturn(response);
 
         // This sets the page attribute injected in the models with @Inject or @ScriptVariable
         SlingBindings slingBindings = (SlingBindings) context.request()
-                                                             .getAttribute(SlingBindings.class.getName());
+            .getAttribute(SlingBindings.class.getName());
         slingBindings.setResource(teaserResource);
         slingBindings.put(WCMBindingsConstants.NAME_CURRENT_PAGE, page);
         slingBindings.put(WCMBindingsConstants.NAME_PROPERTIES, teaserResource.getValueMap());
 
         productTeaser = context.request()
-                               .adaptTo(ProductTeaserImpl.class);
+            .adaptTo(ProductTeaserImpl.class);
     }
 
     @Test
@@ -129,14 +129,14 @@ public class ProductTeaserImplTest {
 
         NumberFormat priceFormatter = NumberFormat.getCurrencyInstance(Locale.US);
         Money amount = product.getPrice()
-                              .getRegularPrice()
-                              .getAmount();
+            .getRegularPrice()
+            .getAmount();
         priceFormatter.setCurrency(Currency.getInstance(amount.getCurrency()
-                                                              .toString()));
+            .toString()));
         Assert.assertEquals(priceFormatter.format(amount.getValue()), productTeaser.getFormattedPrice());
 
         Assert.assertEquals(product.getImage()
-                                   .getUrl(), productTeaser.getImage());
+            .getUrl(), productTeaser.getImage());
     }
 
     @Test
@@ -146,29 +146,29 @@ public class ProductTeaserImplTest {
         // Find the selected variant
         ConfigurableProduct cp = (ConfigurableProduct) product;
         String selection = teaserResource.getValueMap()
-                                         .get("selection", String.class);
+            .get("selection", String.class);
         String variantSku = SiteNavigation.toProductSkus(selection)
-                                          .getRight();
+            .getRight();
         SimpleProduct variant = cp.getVariants()
-                                  .stream()
-                                  .map(v -> v.getProduct())
-                                  .filter(sp -> variantSku.equals(sp.getSku()))
-                                  .findFirst()
-                                  .orElse(null);
+            .stream()
+            .map(v -> v.getProduct())
+            .filter(sp -> variantSku.equals(sp.getSku()))
+            .findFirst()
+            .orElse(null);
 
         Assert.assertEquals(variant.getName(), productTeaser.getName());
         Assert.assertEquals(SiteNavigation.toProductUrl(PAGE, product.getUrlKey(), variantSku), productTeaser.getUrl());
 
         NumberFormat priceFormatter = NumberFormat.getCurrencyInstance(Locale.US);
         Money amount = variant.getPrice()
-                              .getRegularPrice()
-                              .getAmount();
+            .getRegularPrice()
+            .getAmount();
         priceFormatter.setCurrency(Currency.getInstance(amount.getCurrency()
-                                                              .toString()));
+            .toString()));
         Assert.assertEquals(priceFormatter.format(amount.getValue()), productTeaser.getFormattedPrice());
 
         Assert.assertEquals(variant.getImage()
-                                   .getUrl(), productTeaser.getImage());
+            .getUrl(), productTeaser.getImage());
     }
 
     private String getResource(String filename) throws IOException {

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImplTest.java
@@ -51,45 +51,57 @@ public class ProductTeaserImplTest {
     public final AemContext context = createContext("/context/jcr-content.json");
 
     private static AemContext createContext(String contentPath) {
-        return new AemContext(
-            (AemContextCallback) context -> {
-                // Load page structure
-                context.load().json(contentPath, "/content");
-            },
-            ResourceResolverType.JCR_MOCK);
+        return new AemContext((AemContextCallback) context -> {
+            // Load page structure
+            context.load()
+                   .json(contentPath, "/content");
+        }, ResourceResolverType.JCR_MOCK);
     }
 
     private static final String PAGE = "/content/pageA";
+
     private static final String PRODUCTTEASER_SIMPLE = "/content/pageA/jcr:content/root/responsivegrid/productteaser-simple";
+
     private static final String PRODUCTTEASER_VARIANT = "/content/pageA/jcr:content/root/responsivegrid/productteaser-variant";
+
     private static final String PRODUCTTEASER_PATH = "/content/pageA/jcr:content/root/responsivegrid/productteaser-path";
 
     private Resource teaserResource;
+
     private ProductTeaserImpl productTeaser;
+
     private ProductInterface product;
 
     public void setUp(String resourcePath) throws Exception {
         Page page = context.currentPage(PAGE);
         context.currentResource(resourcePath);
-        teaserResource = Mockito.spy(context.resourceResolver().getResource(resourcePath));
+        teaserResource = Mockito.spy(context.resourceResolver()
+                                            .getResource(resourcePath));
 
         String json = getResource("/graphql/magento-graphql-productteaser-result.json");
-        Query rootQuery = QueryDeserializer.getGson().fromJson(json, Query.class);
-        product = rootQuery.getProducts().getItems().get(0);
+        Query rootQuery = QueryDeserializer.getGson()
+                                           .fromJson(json, Query.class);
+        product = rootQuery.getProducts()
+                           .getItems()
+                           .get(0);
 
         GraphqlResponse<Object, Object> response = new GraphqlResponse<>();
         response.setData(rootQuery);
         GraphqlClient graphqlClient = Mockito.mock(GraphqlClient.class);
-        Mockito.when(teaserResource.adaptTo(GraphqlClient.class)).thenReturn(graphqlClient);
-        Mockito.when(graphqlClient.execute(any(), any(), any(), any())).thenReturn(response);
+        Mockito.when(teaserResource.adaptTo(GraphqlClient.class))
+               .thenReturn(graphqlClient);
+        Mockito.when(graphqlClient.execute(any(), any(), any(), any()))
+               .thenReturn(response);
 
         // This sets the page attribute injected in the models with @Inject or @ScriptVariable
-        SlingBindings slingBindings = (SlingBindings) context.request().getAttribute(SlingBindings.class.getName());
+        SlingBindings slingBindings = (SlingBindings) context.request()
+                                                             .getAttribute(SlingBindings.class.getName());
         slingBindings.setResource(teaserResource);
         slingBindings.put(WCMBindingsConstants.NAME_CURRENT_PAGE, page);
         slingBindings.put(WCMBindingsConstants.NAME_PROPERTIES, teaserResource.getValueMap());
 
-        productTeaser = context.request().adaptTo(ProductTeaserImpl.class);
+        productTeaser = context.request()
+                               .adaptTo(ProductTeaserImpl.class);
     }
 
     @Test
@@ -102,6 +114,13 @@ public class ProductTeaserImplTest {
         verifyProduct(PRODUCTTEASER_PATH);
     }
 
+    @Test
+    public void verifyCtaDetails() throws Exception {
+        setUp(PRODUCTTEASER_VARIANT);
+        Assert.assertEquals("addToCart", productTeaser.getCallToAction());
+        Assert.assertEquals("MJ01-XS-Orange", productTeaser.getSku());
+    }
+
     public void verifyProduct(String resourcePath) throws Exception {
         setUp(resourcePath);
 
@@ -109,11 +128,15 @@ public class ProductTeaserImplTest {
         Assert.assertEquals(SiteNavigation.toProductUrl(PAGE, product.getUrlKey()), productTeaser.getUrl());
 
         NumberFormat priceFormatter = NumberFormat.getCurrencyInstance(Locale.US);
-        Money amount = product.getPrice().getRegularPrice().getAmount();
-        priceFormatter.setCurrency(Currency.getInstance(amount.getCurrency().toString()));
+        Money amount = product.getPrice()
+                              .getRegularPrice()
+                              .getAmount();
+        priceFormatter.setCurrency(Currency.getInstance(amount.getCurrency()
+                                                              .toString()));
         Assert.assertEquals(priceFormatter.format(amount.getValue()), productTeaser.getFormattedPrice());
 
-        Assert.assertEquals(product.getImage().getUrl(), productTeaser.getImage());
+        Assert.assertEquals(product.getImage()
+                                   .getUrl(), productTeaser.getImage());
     }
 
     @Test
@@ -122,20 +145,30 @@ public class ProductTeaserImplTest {
 
         // Find the selected variant
         ConfigurableProduct cp = (ConfigurableProduct) product;
-        String selection = teaserResource.getValueMap().get("selection", String.class);
-        String variantSku = SiteNavigation.toProductSkus(selection).getRight();
-        SimpleProduct variant = cp.getVariants().stream().map(v -> v.getProduct()).filter(sp -> variantSku.equals(sp.getSku()))
-            .findFirst().orElse(null);
+        String selection = teaserResource.getValueMap()
+                                         .get("selection", String.class);
+        String variantSku = SiteNavigation.toProductSkus(selection)
+                                          .getRight();
+        SimpleProduct variant = cp.getVariants()
+                                  .stream()
+                                  .map(v -> v.getProduct())
+                                  .filter(sp -> variantSku.equals(sp.getSku()))
+                                  .findFirst()
+                                  .orElse(null);
 
         Assert.assertEquals(variant.getName(), productTeaser.getName());
         Assert.assertEquals(SiteNavigation.toProductUrl(PAGE, product.getUrlKey(), variantSku), productTeaser.getUrl());
 
         NumberFormat priceFormatter = NumberFormat.getCurrencyInstance(Locale.US);
-        Money amount = variant.getPrice().getRegularPrice().getAmount();
-        priceFormatter.setCurrency(Currency.getInstance(amount.getCurrency().toString()));
+        Money amount = variant.getPrice()
+                              .getRegularPrice()
+                              .getAmount();
+        priceFormatter.setCurrency(Currency.getInstance(amount.getCurrency()
+                                                              .toString()));
         Assert.assertEquals(priceFormatter.format(amount.getValue()), productTeaser.getFormattedPrice());
 
-        Assert.assertEquals(variant.getImage().getUrl(), productTeaser.getImage());
+        Assert.assertEquals(variant.getImage()
+                                   .getUrl(), productTeaser.getImage());
     }
 
     private String getResource(String filename) throws IOException {

--- a/bundles/core/src/test/resources/context/jcr-content.json
+++ b/bundles/core/src/test/resources/context/jcr-content.json
@@ -13,7 +13,8 @@
           },
           "productteaser-variant": {
             "selection": "MJ01#MJ01-XS-Orange",
-            "sling:resourceType": "venia/components/commerce/productteaser"
+            "sling:resourceType": "venia/components/commerce/productteaser",
+              "cta": "addToCart"
           },
           "productteaser-path": {
             "selection": "/var/commerce/products/catalog/luma/men/tops-men/jackets-men/MJ01",

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
@@ -40,7 +40,7 @@
                                             <call-to-action jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                             fieldLabel="Call to action"
-                                                            fieldDescription="The call to action to include in the teaser, if any"
+                                                            fieldDescription="The call to action to include in the teaser, if any. Note the the 'Add to cart' option only works for simple/variant products"
                                                             name="./cta">
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <none jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
@@ -1,41 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    jcr:title="Product Teaser"
-    sling:resourceType="cq/gui/components/authoring/dialog"
-    trackingFeature="cif-core-components:productteaser:v1">
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Product Teaser"
+          sling:resourceType="cq/gui/components/authoring/dialog"
+          trackingFeature="cif-core-components:productteaser:v1">
     <content
-        jcr:primaryType="nt:unstructured"
-        sling:resourceType="granite/ui/components/coral/foundation/container">
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/container">
         <items jcr:primaryType="nt:unstructured">
             <tabs
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="granite/ui/components/coral/foundation/tabs"
-                maximized="{Boolean}true">
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                    maximized="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
                     <properties
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Properties"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
+                            jcr:primaryType="nt:unstructured"
+                            jcr:title="Properties"
+                            sling:resourceType="granite/ui/components/coral/foundation/container"
+                            margin="{Boolean}true">
                         <items jcr:primaryType="nt:unstructured">
                             <columns
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                margin="{Boolean}true">
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                    margin="{Boolean}true">
                                 <items jcr:primaryType="nt:unstructured">
                                     <column
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
                                             <product
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="/libs/commerce/gui/components/common/cifproductfield"
-                                                fieldDescription="The product or product variant displayed by the teaser"
-                                                fieldLabel="Select Product"
-                                                filter="folderOrProductOrVariant"
-                                                name="./selection"
-                                                selectionId="combinedSku"/>
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="/libs/commerce/gui/components/common/cifproductfield"
+                                                    fieldDescription="The product or product variant displayed by the teaser"
+                                                    fieldLabel="Select Product"
+                                                    filter="folderOrProductOrVariant"
+                                                    name="./selection"
+                                                    selectionId="combinedSku"/>
+
+                                            <call-to-action jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            fieldLabel="Call to action"
+                                                            fieldDescription="The call to action to include in the teaser, if any"
+                                                            name="./cta">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <none jcr:primaryType="nt:unstructured"
+                                                          selected="{Boolean}true"
+                                                          text="None"
+                                                          value=""/>
+                                                    <add-to-cart jcr:primaryType="nt:unstructured"
+                                                                 text="Add to cart"
+                                                                 value="add-to-cart"/>
+                                                    <details jcr:primaryType="nt:unstructured"
+                                                             text="See more details"
+                                                             value="details"/>
+                                                </items>
+                                            </call-to-action>
                                         </items>
                                     </column>
                                 </items>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/actions.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/actions.html
@@ -1,0 +1,27 @@
+<!--/*
+    Copyright 2019 Adobe Systems Incorporated
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/-->
+<template data-sly-template.actions ="${@ product}">
+    <div class="productteaser__cta" data-sly-test="${product.callToAction != null}">
+        <button data-sly-test="${product.callToAction == 'add-to-cart'}" data-action="addToCart" data-item-sku="${product.sku}"
+                class="button__root_highPriority button__root clickable__root button__filled" type="button">
+            <span class="button__content"><span>Add to Cart</span></span>
+        </button>
+        <button data-sly-test="${product.callToAction == 'details'}" data-action="details" data-url="${product.url}"
+                class="button__root_highPriority button__root clickable__root button__filled" type="button">
+            <span class="button__content"><span>See more details</span></span>
+        </button>
+    </div>
+</template>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/.content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          allowProxy="{Boolean}true"
+          categories="[core.cif.components.productteaser.v1]"
+          dependencies="[core.cif.components.common]">
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js.txt
@@ -1,0 +1,1 @@
+dist/index.js

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -15,9 +15,7 @@
 'use strict';
 
 class ProductTeaser {
-
     constructor(rootElement) {
-
         rootElement.forEach(node => {
             const actionButton = node.querySelector(`.productteaser__cta button`);
             const action = actionButton.dataset['action'];
@@ -32,7 +30,7 @@ class ProductTeaser {
                 };
             }
 
-            actionButton.addEventListener('click', (ev) => {
+            actionButton.addEventListener('click', ev => {
                 const element = ev.currentTarget;
                 actionHandler(element);
             });
@@ -42,23 +40,22 @@ class ProductTeaser {
     _addToCartHandler(button) {
         const sku = button.dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
-            detail: {sku, quantity: 1}
+            detail: { sku, quantity: 1 }
         });
         document.dispatchEvent(customEvent);
-    };
+    }
 
     _seeDetailsHandler(button) {
         const url = button.dataset['url'];
         window.location = url;
-    };
-
+    }
 }
 
 ProductTeaser.selectors = {
-    rootElement: "[data-cmp-is=productteaser]"
+    rootElement: '[data-cmp-is=productteaser]'
 };
 
-(function (doc) {
+(function(doc) {
     function onDocumentReady() {
         const rootElement = doc.querySelectorAll(ProductTeaser.selectors.rootElement);
         new ProductTeaser(rootElement);

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -16,12 +16,11 @@
 
 const LocationAdapter = {
     setHref(url) {
-        window.location.assign(url)
-    },
+        window.location.assign(url);
+    }
 };
 
 class ProductTeaser {
-
     constructor(element) {
         const actionButton = element.querySelector(`.productteaser__cta button`);
         const action = actionButton.dataset['action'];
@@ -45,7 +44,7 @@ class ProductTeaser {
     _addToCartHandler(dataset) {
         const sku = dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
-            detail: {sku, quantity: 1}
+            detail: { sku, quantity: 1 }
         });
         document.dispatchEvent(customEvent);
     }
@@ -60,10 +59,10 @@ ProductTeaser.selectors = {
     rootElement: '[data-cmp-is=productteaser]'
 };
 
-export {LocationAdapter}
+export { LocationAdapter };
 export default ProductTeaser;
 
-(function (doc) {
+(function(doc) {
     function onDocumentReady() {
         const rootElements = doc.querySelectorAll(ProductTeaser.selectors.rootElement);
         rootElements.forEach(element => new ProductTeaser(element));

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -11,47 +11,62 @@
  *    governing permissions and limitations under the License.
  *
  ******************************************************************************/
+
 'use strict';
-(function(channel) {
-    const addToCartHandler = ev => {
-        const button = ev.currentTarget;
-        const sku = button.dataset['itemSku'];
-        const customEvent = new CustomEvent('aem.cif.add-to-cart', {
-            detail: { sku, quantity: 1 }
-        });
-        document.dispatchEvent(customEvent);
-    };
 
-    const seeDetailsHandler = ev => {
-        const button = ev.currentTarget;
-        const url = button.dataset['url'];
-        window.location = url;
-    };
+class ProductTeaser {
 
-    const initializeTeaserAction = function() {
-        console.log(`Let's initialize this!`);
-        const actionButtons = channel.querySelectorAll('.productteaser__cta button');
+    constructor(rootElement) {
 
-        actionButtons.forEach(node => {
-            const action = node.dataset['action'];
+        rootElement.forEach(node => {
+            const actionButton = node.querySelector(`.productteaser__cta button`);
+            const action = actionButton.dataset['action'];
             let actionHandler;
             if (action === 'addToCart') {
-                actionHandler = addToCartHandler;
+                actionHandler = this._addToCartHandler;
             } else if (action === 'details') {
-                actionHandler = seeDetailsHandler;
+                actionHandler = this._seeDetailsHandler;
             } else {
                 actionHandler = () => {
                     /* NOOP */
                 };
             }
 
-            node.addEventListener('click', actionHandler);
+            actionButton.addEventListener('click', (ev) => {
+                const element = ev.currentTarget;
+                actionHandler(element);
+            });
         });
+    }
+
+    _addToCartHandler(button) {
+        const sku = button.dataset['itemSku'];
+        const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+            detail: {sku, quantity: 1}
+        });
+        document.dispatchEvent(customEvent);
     };
 
+    _seeDetailsHandler(button) {
+        const url = button.dataset['url'];
+        window.location = url;
+    };
+
+}
+
+ProductTeaser.selectors = {
+    rootElement: "[data-cmp-is=productteaser]"
+};
+
+(function (doc) {
+    function onDocumentReady() {
+        const rootElement = doc.querySelectorAll(ProductTeaser.selectors.rootElement);
+        new ProductTeaser(rootElement);
+    }
+
     if (document.readyState !== 'loading') {
-        initializeTeaserAction();
+        onDocumentReady();
     } else {
-        document.addEventListener('DOMContentLoaded', initializeTeaserAction);
+        document.addEventListener('DOMContentLoaded', onDocumentReady);
     }
 })(window.document);

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -15,6 +15,7 @@
 'use strict';
 
 class ProductTeaser {
+
     constructor(element) {
         const actionButton = element.querySelector(`.productteaser__cta button`);
         const action = actionButton.dataset['action'];
@@ -31,21 +32,21 @@ class ProductTeaser {
 
         actionButton.addEventListener('click', ev => {
             const element = ev.currentTarget;
-            actionHandler(element);
+            actionHandler(element.dataset);
         });
     }
 
-    _addToCartHandler(button) {
-        const sku = button.dataset['itemSku'];
+    _addToCartHandler(dataset) {
+        const sku = dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
-            detail: {sku, quantity: 1}
+            detail: { sku, quantity: 1 }
         });
         document.dispatchEvent(customEvent);
     }
 
-    _seeDetailsHandler(button) {
-        const url = button.dataset['url'];
-        window.location = url;
+    _seeDetailsHandler(dataset) {
+        const url = dataset['url'];
+        window.location.assign(url);
     }
 }
 
@@ -53,10 +54,12 @@ ProductTeaser.selectors = {
     rootElement: '[data-cmp-is=productteaser]'
 };
 
-(function (doc) {
+export default ProductTeaser;
+
+(function(doc) {
     function onDocumentReady() {
         const rootElements = doc.querySelectorAll(ProductTeaser.selectors.rootElement);
-        rootElements.forEach(element => new ProductTeaser(element))
+        rootElements.forEach(element => new ProductTeaser(element));
     }
 
     if (document.readyState !== 'loading') {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+'use strict';
+(function (channel) {
+    const addToCartHandler = ev => {
+        const button = ev.currentTarget;
+        const sku = button.dataset['itemSku'];
+        const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+            detail: {sku, quantity: 1}
+        });
+        document.dispatchEvent(customEvent);
+    };
+
+    const seeDetailsHandler = ev => {
+        const button = ev.currentTarget;
+        const url = button.dataset['url'];
+        window.location = url;
+    };
+
+    const initializeTeaserAction = function () {
+        console.log(`Let's initialize this!`);
+        const actionButtons = channel.querySelectorAll('.productteaser__cta button');
+
+        actionButtons.forEach(node => {
+            const action = node.dataset['action'];
+            let actionHandler;
+            if (action === 'addToCart') {
+                actionHandler = addToCartHandler;
+            } else if (action === 'details') {
+                actionHandler = seeDetailsHandler;
+            } else {
+                actionHandler = () => {
+                    /* NOOP */
+                };
+            }
+
+            node.addEventListener('click', actionHandler);
+        })
+    };
+
+    if (document.readyState !== 'loading') {
+        initializeTeaserAction();
+    } else {
+        document.addEventListener('DOMContentLoaded', initializeTeaserAction);
+    }
+
+})(window.document);

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -40,7 +40,9 @@ class ProductTeaser {
             actionHandler(element.dataset);
         });
     }
-
+    setHref(url) {
+        window.location.assign(url);
+    }
     _addToCartHandler(dataset) {
         const sku = dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
@@ -51,7 +53,7 @@ class ProductTeaser {
 
     _seeDetailsHandler(dataset) {
         const url = dataset['url'];
-        LocationAdapter.setHref(url);
+        this.setHref(url);
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -14,6 +14,12 @@
 
 'use strict';
 
+const LocationAdapter = {
+    setHref(url) {
+        window.location.assign(url)
+    },
+};
+
 class ProductTeaser {
 
     constructor(element) {
@@ -39,14 +45,14 @@ class ProductTeaser {
     _addToCartHandler(dataset) {
         const sku = dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
-            detail: { sku, quantity: 1 }
+            detail: {sku, quantity: 1}
         });
         document.dispatchEvent(customEvent);
     }
 
     _seeDetailsHandler(dataset) {
         const url = dataset['url'];
-        window.location.assign(url);
+        LocationAdapter.setHref(url);
     }
 }
 
@@ -54,9 +60,10 @@ ProductTeaser.selectors = {
     rootElement: '[data-cmp-is=productteaser]'
 };
 
+export {LocationAdapter}
 export default ProductTeaser;
 
-(function(doc) {
+(function (doc) {
     function onDocumentReady() {
         const rootElements = doc.querySelectorAll(ProductTeaser.selectors.rootElement);
         rootElements.forEach(element => new ProductTeaser(element));

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -23,22 +23,29 @@ const LocationAdapter = {
 class ProductTeaser {
     constructor(element) {
         const actionButton = element.querySelector(`.productteaser__cta button`);
-        const action = actionButton.dataset['action'];
-        let actionHandler;
-        if (action === 'addToCart') {
-            actionHandler = this._addToCartHandler;
-        } else if (action === 'details') {
-            actionHandler = this._seeDetailsHandler;
-        } else {
-            actionHandler = () => {
-                /* NOOP */
-            };
-        }
+        if (actionButton != null) {
+            const action = actionButton.dataset['action'];
+            let actionHandler;
+            switch (action) {
+                case 'addToCart':
+                    actionHandler = this._addToCartHandler;
+                    break;
+                case 'details':
+                    actionHandler = this._seeDetailsHandler;
+                    break;
+                default:
+                    actionHandler = this._noOpHandler;
+            }
 
-        actionButton.addEventListener('click', ev => {
-            const element = ev.currentTarget;
-            actionHandler(element.dataset);
-        });
+            actionButton.addEventListener('click', ev => {
+                const element = ev.currentTarget;
+                actionHandler(element.dataset);
+            });
+        }
+    }
+
+    _noOpHandler() {
+        /* As the name says... NOOP */
     }
 
     _addToCartHandler(dataset) {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -12,12 +12,12 @@
  *
  ******************************************************************************/
 'use strict';
-(function (channel) {
+(function(channel) {
     const addToCartHandler = ev => {
         const button = ev.currentTarget;
         const sku = button.dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
-            detail: {sku, quantity: 1}
+            detail: { sku, quantity: 1 }
         });
         document.dispatchEvent(customEvent);
     };
@@ -28,7 +28,7 @@
         window.location = url;
     };
 
-    const initializeTeaserAction = function () {
+    const initializeTeaserAction = function() {
         console.log(`Let's initialize this!`);
         const actionButtons = channel.querySelectorAll('.productteaser__cta button');
 
@@ -46,7 +46,7 @@
             }
 
             node.addEventListener('click', actionHandler);
-        })
+        });
     };
 
     if (document.readyState !== 'loading') {
@@ -54,5 +54,4 @@
     } else {
         document.addEventListener('DOMContentLoaded', initializeTeaserAction);
     }
-
 })(window.document);

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -15,32 +15,30 @@
 'use strict';
 
 class ProductTeaser {
-    constructor(rootElement) {
-        rootElement.forEach(node => {
-            const actionButton = node.querySelector(`.productteaser__cta button`);
-            const action = actionButton.dataset['action'];
-            let actionHandler;
-            if (action === 'addToCart') {
-                actionHandler = this._addToCartHandler;
-            } else if (action === 'details') {
-                actionHandler = this._seeDetailsHandler;
-            } else {
-                actionHandler = () => {
-                    /* NOOP */
-                };
-            }
+    constructor(element) {
+        const actionButton = element.querySelector(`.productteaser__cta button`);
+        const action = actionButton.dataset['action'];
+        let actionHandler;
+        if (action === 'addToCart') {
+            actionHandler = this._addToCartHandler;
+        } else if (action === 'details') {
+            actionHandler = this._seeDetailsHandler;
+        } else {
+            actionHandler = () => {
+                /* NOOP */
+            };
+        }
 
-            actionButton.addEventListener('click', ev => {
-                const element = ev.currentTarget;
-                actionHandler(element);
-            });
+        actionButton.addEventListener('click', ev => {
+            const element = ev.currentTarget;
+            actionHandler(element);
         });
     }
 
     _addToCartHandler(button) {
         const sku = button.dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
-            detail: { sku, quantity: 1 }
+            detail: {sku, quantity: 1}
         });
         document.dispatchEvent(customEvent);
     }
@@ -55,10 +53,10 @@ ProductTeaser.selectors = {
     rootElement: '[data-cmp-is=productteaser]'
 };
 
-(function(doc) {
+(function (doc) {
     function onDocumentReady() {
-        const rootElement = doc.querySelectorAll(ProductTeaser.selectors.rootElement);
-        new ProductTeaser(rootElement);
+        const rootElements = doc.querySelectorAll(ProductTeaser.selectors.rootElement);
+        rootElements.forEach(element => new ProductTeaser(element))
     }
 
     if (document.readyState !== 'loading') {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -40,9 +40,7 @@ class ProductTeaser {
             actionHandler(element.dataset);
         });
     }
-    setHref(url) {
-        window.location.assign(url);
-    }
+
     _addToCartHandler(dataset) {
         const sku = dataset['itemSku'];
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
@@ -53,7 +51,7 @@ class ProductTeaser {
 
     _seeDetailsHandler(dataset) {
         const url = dataset['url'];
-        this.setHref(url);
+        LocationAdapter.setHref(url);
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
@@ -15,28 +15,20 @@
 */-->
 
 <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
-     data-sly-use.product="com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser">
+     data-sly-use.product="com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser"
+     data-sly-use.actionsTpl="actions.html">
     <sly data-sly-call="${clientlib.all @ categories='core.cif.components.productteaser.v1'}"></sly>
     <sly data-sly-test.ispropavailable="${properties.selection}">
         <div data-sly-test.isvalid="${product.url}" class="item__root" data-cmp-is="productteaser">
             <a class="item__images" href=${product.url}>
                 <img class="item__image" width="100%" height="100%"
                      src="${product.image}" alt="${product.image}"/>
-            </a>                                
+            </a>
             <a class="item__name" href=${product.url}><span>${product.name}</span></a>
             <div class="item__price">
                 <span> ${product.formattedPrice} </span>
             </div>
-            <div class="productteaser__cta" data-sly-test="${product.callToAction != null}">
-                <button data-sly-test="${product.callToAction == 'add-to-cart'}" data-action="addToCart" data-item-sku="${product.sku}"
-                        class="button__root_highPriority button__root clickable__root button__filled" type="button">
-                    <span class="button__content"><span>Add to Cart</span></span>
-                </button>
-                <button data-sly-test="${product.callToAction == 'details'}" data-action="details" data-url="${product.url}"
-                        class="button__root_highPriority button__root clickable__root button__filled" type="button">
-                    <span class="button__content"><span>See more details</span></span>
-                </button>
-            </div>
+            <sly data-sly-call="${actionsTpl.actions @ product=product}"></sly>
         </div>
         <!-- Condition if the product is not available, or invalid sku provided -->
         <div class="blank-placeholder" data-sly-test=${!isvalid}>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
@@ -16,15 +16,26 @@
 
 <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-use.product="com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser">
+    <sly data-sly-call="${clientlib.all @ categories='core.cif.components.productteaser.v1'}"></sly>
     <sly data-sly-test.ispropavailable="${properties.selection}">
         <div data-sly-test.isvalid="${product.url}" class="item__root">
             <a class="item__images" href=${product.url}>
                 <img class="item__image" width="100%" height="100%"
                      src="${product.image}" alt="${product.image}"/>
-            </a>
+            </a>                                
             <a class="item__name" href=${product.url}><span>${product.name}</span></a>
             <div class="item__price">
                 <span> ${product.formattedPrice} </span>
+            </div>
+            <div class="productteaser__cta" data-sly-test="${product.callToAction != null}">
+                <button data-sly-test="${product.callToAction == 'add-to-cart'}" data-action="addToCart" data-item-sku="${product.sku}"
+                        class="button__root_highPriority button__root clickable__root button__filled" type="button">
+                    <span class="button__content"><span>Add to Cart</span></span>
+                </button>
+                <button data-sly-test="${product.callToAction == 'details'}" data-action="details" data-url="${product.url}"
+                        class="button__root_highPriority button__root clickable__root button__filled" type="button">
+                    <span class="button__content"><span>See more details</span></span>
+                </button>
             </div>
         </div>
         <!-- Condition if the product is not available, or invalid sku provided -->

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
@@ -18,7 +18,7 @@
      data-sly-use.product="com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser">
     <sly data-sly-call="${clientlib.all @ categories='core.cif.components.productteaser.v1'}"></sly>
     <sly data-sly-test.ispropavailable="${properties.selection}">
-        <div data-sly-test.isvalid="${product.url}" class="item__root">
+        <div data-sly-test.isvalid="${product.url}" class="item__root" data-cmp-is="productteaser">
             <a class="item__images" href=${product.url}>
                 <img class="item__image" width="100%" height="100%"
                      src="${product.image}" alt="${product.image}"/>

--- a/ui.apps/test/components/commerce/productteaser/actionsTest.js
+++ b/ui.apps/test/components/commerce/productteaser/actionsTest.js
@@ -27,6 +27,11 @@ let seeMoreDetailsAction = `<button data-action="details" data-url="/some/random
             <span class="button__content"><span>See more details</span></span>
         </button>`;
 
+let misconfiguredAction = `<button data-action="" data-url="/some/random/url"
+                class="button__root_highPriority button__root clickable__root button__filled" type="button">
+            <span class="button__content"><span>See more details</span></span>
+        </button>`;
+
 let generateTeaserHtml = button => `<div class="item__root" data-cmp-is="productteaser">
   <a class="item__images" href="#"></a>
   <a class="item__name" href="#"><span>Sample product</span></a>
@@ -45,6 +50,7 @@ describe('ProductTeaser', () => {
 
     before(() => {
         mockLocation = sinon.mock(LocationAdapter);
+        sinon.spy(ProductTeaser.prototype, '_noOpHandler');
 
         let body = document.querySelector('body');
         pageRoot = document.createElement('div');
@@ -59,6 +65,7 @@ describe('ProductTeaser', () => {
 
     after(() => {
         pageRoot.parentNode.removeChild(pageRoot);
+        ProductTeaser.prototype._noOpHandler.restore();
     });
 
     it('triggers the cart addition event for the Add To Cart CTA', () => {
@@ -93,5 +100,14 @@ describe('ProductTeaser', () => {
         const button = teaserRoot.querySelector('button');
         button.click();
         mockLocation.verify();
+    });
+
+    it("doesn't do anything if the CTA is misconfigured", () => {
+        pageRoot.insertAdjacentHTML('afterbegin', generateTeaserHtml(misconfiguredAction));
+        teaserRoot = pageRoot.querySelector(ProductTeaser.selectors.rootElement);
+        const productTeaser = new ProductTeaser(teaserRoot);
+        const button = teaserRoot.querySelector('button');
+        button.click();
+        assert(productTeaser._noOpHandler.called);
     });
 });

--- a/ui.apps/test/components/commerce/productteaser/actionsTest.js
+++ b/ui.apps/test/components/commerce/productteaser/actionsTest.js
@@ -13,7 +13,9 @@
  ******************************************************************************/
 'use strict';
 
-import ProductTeaser, {LocationAdapter} from '../../../../src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions';
+import ProductTeaser, {
+    LocationAdapter
+} from '../../../../src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions';
 
 let addToCartAction = `<button data-action="addToCart" data-item-sku="1234"
                 class="button__root_highPriority button__root clickable__root button__filled" type="button">
@@ -25,7 +27,7 @@ let seeMoreDetailsAction = `<button data-action="details" data-url="/some/random
             <span class="button__content"><span>See more details</span></span>
         </button>`;
 
-let generateTeaserHtml = (button) => `<div class="item__root" data-cmp-is="productteaser">
+let generateTeaserHtml = button => `<div class="item__root" data-cmp-is="productteaser">
   <a class="item__images" href="#"></a>
   <a class="item__name" href="#"><span>Sample product</span></a>
     <div class="item__price">
@@ -54,7 +56,6 @@ describe('ProductTeaser', () => {
     });
 
     it('triggers the cart addition event for the Add To Cart CTA', () => {
-
         while (pageRoot.firstChild) {
             pageRoot.removeChild(pageRoot.firstChild);
         }
@@ -78,7 +79,10 @@ describe('ProductTeaser', () => {
     });
 
     it('navigates to another location for the See Details CTA', () => {
-        mockLocation.expects("setHref").atLeast(1).withArgs("/some/random/url");
+        mockLocation
+            .expects('setHref')
+            .atLeast(1)
+            .withArgs('/some/random/url');
         while (pageRoot.firstChild) {
             pageRoot.removeChild(pageRoot.firstChild);
         }
@@ -89,6 +93,6 @@ describe('ProductTeaser', () => {
         const productTeaser = new ProductTeaser(teaserRoot);
         const button = teaserRoot.querySelector('button');
         button.click();
-        mockLocation.verify()
+        mockLocation.verify();
     });
 });

--- a/ui.apps/test/components/commerce/productteaser/actionsTest.js
+++ b/ui.apps/test/components/commerce/productteaser/actionsTest.js
@@ -51,7 +51,7 @@ describe('ProductTeaser', () => {
         body.appendChild(pageRoot);
     });
 
-    beforeEach(()=>{
+    beforeEach(() => {
         while (pageRoot.firstChild) {
             pageRoot.removeChild(pageRoot.firstChild);
         }
@@ -62,7 +62,6 @@ describe('ProductTeaser', () => {
     });
 
     it('triggers the cart addition event for the Add To Cart CTA', () => {
-
         pageRoot.insertAdjacentHTML('afterbegin', generateTeaserHtml(addToCartAction));
         teaserRoot = pageRoot.querySelector(ProductTeaser.selectors.rootElement);
 

--- a/ui.apps/test/components/commerce/productteaser/actionsTest.js
+++ b/ui.apps/test/components/commerce/productteaser/actionsTest.js
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+'use strict';
+
+import ProductTeaser from '../../../../src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js';
+
+let addToCartAction = `<button data-action="addToCart" data-item-sku="1234"
+                class="button__root_highPriority button__root clickable__root button__filled" type="button">
+            <span class="button__content"><span>Add to Cart</span></span>
+        </button>`;
+
+let seeMoreDetailsAction = `<button data-action="details" data-url="/some/random/url"
+                class="button__root_highPriority button__root clickable__root button__filled" type="button">
+            <span class="button__content"><span>See more details</span></span>
+        </button>`;
+
+let generateTeaserHtml = (button) => `<div class="item__root" data-cmp-is="productteaser">
+  <a class="item__images" href="#"></a>
+  <a class="item__name" href="#"><span>Sample product</span></a>
+    <div class="item__price">
+        <span> $0.99</span>
+    </div>
+    <div class="productteaser__cta">
+       ${button}
+    </div>      
+</div>`;
+
+describe('ProductTeaser', () => {
+    let pageRoot;
+    let teaserRoot;
+    let fakeAssign;
+
+    before(() => {
+
+        sinon.stub(window.location, 'assign').callsFake(() => true);
+        let body = document.querySelector('body');
+        pageRoot = document.createElement('div');
+        body.appendChild(pageRoot);
+    });
+
+    after(() => {
+        pageRoot.parentNode.removeChild(pageRoot);
+    });
+
+    it('triggers the cart addition event for the Add To Cart CTA', () => {
+
+        while (pageRoot.firstChild) {
+            pageRoot.removeChild(pageRoot.firstChild);
+        }
+
+        pageRoot.insertAdjacentHTML('afterbegin', generateTeaserHtml(addToCartAction));
+        teaserRoot = pageRoot.querySelector(ProductTeaser.selectors.rootElement);
+
+        document.addEventListener('aem.cif.add-to-cart', () => {
+            let response = document.createElement('div');
+            response.classList.add('response');
+            response.innerText = 'event triggered';
+            pageRoot.appendChild(response);
+        });
+
+        console.log("Root o' the teaser", teaserRoot);
+        const productTeaser = new ProductTeaser(teaserRoot);
+        const button = teaserRoot.querySelector('button');
+        button.click();
+
+        const response = pageRoot.querySelector('div.response');
+        assert.isNotNull(response);
+    });
+
+    it('navigates to another location for the See Details CTA', () => {
+
+        while (pageRoot.firstChild) {
+            pageRoot.removeChild(pageRoot.firstChild);
+        }
+
+        pageRoot.insertAdjacentHTML('afterbegin', generateTeaserHtml(seeMoreDetailsAction));
+        teaserRoot = pageRoot.querySelector(ProductTeaser.selectors.rootElement);
+
+        console.log("Root o' the teaser", teaserRoot);
+        const productTeaser = new ProductTeaser(teaserRoot);
+        const button = teaserRoot.querySelector('button');
+        button.click();
+        window.location.assign.should.be.true;
+        
+    });
+});

--- a/ui.apps/test/components/commerce/productteaser/actionsTest.js
+++ b/ui.apps/test/components/commerce/productteaser/actionsTest.js
@@ -51,14 +51,17 @@ describe('ProductTeaser', () => {
         body.appendChild(pageRoot);
     });
 
+    beforeEach(()=>{
+        while (pageRoot.firstChild) {
+            pageRoot.removeChild(pageRoot.firstChild);
+        }
+    });
+
     after(() => {
         pageRoot.parentNode.removeChild(pageRoot);
     });
 
     it('triggers the cart addition event for the Add To Cart CTA', () => {
-        while (pageRoot.firstChild) {
-            pageRoot.removeChild(pageRoot.firstChild);
-        }
 
         pageRoot.insertAdjacentHTML('afterbegin', generateTeaserHtml(addToCartAction));
         teaserRoot = pageRoot.querySelector(ProductTeaser.selectors.rootElement);
@@ -83,9 +86,6 @@ describe('ProductTeaser', () => {
             .expects('setHref')
             .atLeast(1)
             .withArgs('/some/random/url');
-        while (pageRoot.firstChild) {
-            pageRoot.removeChild(pageRoot.firstChild);
-        }
 
         pageRoot.insertAdjacentHTML('afterbegin', generateTeaserHtml(seeMoreDetailsAction));
         teaserRoot = pageRoot.querySelector(ProductTeaser.selectors.rootElement);

--- a/ui.apps/test/components/commerce/productteaser/actionsTest.js
+++ b/ui.apps/test/components/commerce/productteaser/actionsTest.js
@@ -13,7 +13,7 @@
  ******************************************************************************/
 'use strict';
 
-import ProductTeaser from '../../../../src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js';
+import ProductTeaser, {LocationAdapter} from '../../../../src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions';
 
 let addToCartAction = `<button data-action="addToCart" data-item-sku="1234"
                 class="button__root_highPriority button__root clickable__root button__filled" type="button">
@@ -39,11 +39,11 @@ let generateTeaserHtml = (button) => `<div class="item__root" data-cmp-is="produ
 describe('ProductTeaser', () => {
     let pageRoot;
     let teaserRoot;
-    let fakeAssign;
+    let mockLocation;
 
     before(() => {
+        mockLocation = sinon.mock(LocationAdapter);
 
-        sinon.stub(window.location, 'assign').callsFake(() => true);
         let body = document.querySelector('body');
         pageRoot = document.createElement('div');
         body.appendChild(pageRoot);
@@ -69,7 +69,6 @@ describe('ProductTeaser', () => {
             pageRoot.appendChild(response);
         });
 
-        console.log("Root o' the teaser", teaserRoot);
         const productTeaser = new ProductTeaser(teaserRoot);
         const button = teaserRoot.querySelector('button');
         button.click();
@@ -79,7 +78,7 @@ describe('ProductTeaser', () => {
     });
 
     it('navigates to another location for the See Details CTA', () => {
-
+        mockLocation.expects("setHref").atLeast(1).withArgs("/some/random/url");
         while (pageRoot.firstChild) {
             pageRoot.removeChild(pageRoot.firstChild);
         }
@@ -87,11 +86,9 @@ describe('ProductTeaser', () => {
         pageRoot.insertAdjacentHTML('afterbegin', generateTeaserHtml(seeMoreDetailsAction));
         teaserRoot = pageRoot.querySelector(ProductTeaser.selectors.rootElement);
 
-        console.log("Root o' the teaser", teaserRoot);
         const productTeaser = new ProductTeaser(teaserRoot);
         const button = teaserRoot.querySelector('button');
         button.click();
-        window.location.assign.should.be.true;
-        
+        mockLocation.verify()
     });
 });

--- a/ui.apps/webpack.config.js
+++ b/ui.apps/webpack.config.js
@@ -22,7 +22,8 @@ const LIB = {
     PRODUCTCAROUSEL: 'apps/core/cif/components/commerce/productcarousel/v1/productcarousel/clientlibs',
     PRODUCTLIST: 'apps/core/cif/components/commerce/productlist/v1/productlist/clientlibs',
     SEARCHBAR: 'apps/core/cif/components/commerce/searchbar/v1/searchbar/clientlibs',
-    NAVIGATION: 'apps/core/cif/components/structure/navigation/v1/navigation/clientlibs'
+    NAVIGATION: 'apps/core/cif/components/structure/navigation/v1/navigation/clientlibs',
+    PRODUCTTEASER: 'apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs',
 };
 
 function generateBaseConfig() {
@@ -36,7 +37,8 @@ function generateBaseConfig() {
             [LIB.PRODUCTCAROUSEL]: glob.sync(JCR_ROOT + LIB.PRODUCTCAROUSEL + '/js/**/*.js'),
             [LIB.PRODUCTLIST]: glob.sync(JCR_ROOT + LIB.PRODUCTLIST + '/js/**/*.js'),
             [LIB.SEARCHBAR]: glob.sync(JCR_ROOT + LIB.SEARCHBAR + '/js/**/*.js'),
-            [LIB.NAVIGATION]: glob.sync(JCR_ROOT + LIB.NAVIGATION + '/js/**/*.js')
+            [LIB.NAVIGATION]: glob.sync(JCR_ROOT + LIB.NAVIGATION + '/js/**/*.js'),
+            [LIB.PRODUCTTEASER]:glob.sync(`${JCR_ROOT}${LIB.PRODUCTTEASER}/js/**/*.js`)
         },
         output: {
             path: path.resolve(__dirname, "src/main/content/jcr_root"),


### PR DESCRIPTION
## Description

Allow authors to configure a Call-to-action button for the Product Teaser component. The Call To Action can be one of the following:

* "Add To Cart" - add the selected variation to the cart
* "See More Details" - navigate to the PDP for that product

## Related Issue

CIF-1175

## Motivation and Context

Allow visitor conversions from the teaser component

## How Has This Been Tested?

Functional testing

## Screenshots (if appropriate):

![Screenshot 2019-12-17 at 14 47 53](https://user-images.githubusercontent.com/1407821/70996818-432ae500-20dc-11ea-949f-e9c7e4a85978.png)

![Screenshot 2019-12-17 at 14 47 41](https://user-images.githubusercontent.com/1407821/70996826-4920c600-20dc-11ea-94de-8665ade82bcb.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
