### PR TITLE
CIF-1149 - Fixed the MSM rollout of multi site/store content structures and make cq:graphqlClient property only editable on the site root page

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
@@ -38,7 +38,7 @@ import com.day.cq.wcm.api.PageManager;
 
 /**
  * This is a wrapper class for {@link GraphqlClient}. The constructor adapts a {@link Resource} to
- * the GraphqlClient class and also looks for the <code>cq:magentoStore</code> property on the resource
+ * the GraphqlClient class and also looks for the <code>magentoStore</code> property on the resource
  * path in order to set the Magento <code>Store</code> HTTP header. This wrapper also sets the custom
  * Magento Gson deserializer from {@link QueryDeserializer}.
  */
@@ -46,7 +46,7 @@ public class MagentoGraphqlClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MagentoGraphqlClient.class);
 
-    public static final String STORE_CODE_PROPERTY = "cq:magentoStore";
+    public static final String STORE_CODE_PROPERTY = "magentoStore";
 
     private GraphqlClient graphqlClient;
     private RequestOptions requestOptions;
@@ -82,7 +82,16 @@ public class MagentoGraphqlClient {
         } else {
             properties = new ComponentInheritanceValueMap(resource);
         }
+
+        // get Magento store code
         String storeCode = properties.getInherited(STORE_CODE_PROPERTY, String.class);
+        // for backward compatibility also check of the old cq:magentoStore property
+        if (storeCode == null) {
+            storeCode = properties.getInherited("cq:" + STORE_CODE_PROPERTY, String.class);
+            if (storeCode != null) {
+                LOGGER.warn("Deprecated 'cq:magentoStore' still in use for {}. Please update to 'magentoStore'.", resource.getPath());
+            }
+        }
         if (storeCode != null) {
             Header storeHeader = new BasicHeader("Store", storeCode);
             requestOptions.withHeaders(Collections.singletonList(storeHeader));

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeviewexporter/StoreViewExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeviewexporter/StoreViewExporterImpl.java
@@ -32,7 +32,7 @@ import com.day.cq.wcm.api.Page;
 public class StoreViewExporterImpl implements StoreViewExporter {
 
     protected static final String RESOURCE_TYPE = "core/cif/components/structure/page/v1/page";
-    private static final String STORE_CODE_PROPERTY = "cq:magentoStore";
+    private static final String STORE_CODE_PROPERTY = "magentoStore";
 
     @Inject
     private Page currentPage;

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClientTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClientTest.java
@@ -75,28 +75,43 @@ public class MagentoGraphqlClientTest {
 
     @Test
     public void testMagentoStoreProperty() {
-        // Get page which has the cq:magentoStore property in its jcr:content node
+        // Get page which has the magentoStore property in its jcr:content node
         Resource resource = Mockito.spy(context.resourceResolver().getResource("/content/pageA"));
         testMagentoStoreProperty(resource, true);
     }
 
     @Test
     public void testInheritedMagentoStoreProperty() {
-        // Get page whose parent has the cq:magentoStore property in its jcr:content node
+        // Get page whose parent has the magentoStore property in its jcr:content node
         Resource resource = Mockito.spy(context.resourceResolver().getResource("/content/pageB/pageC"));
         testMagentoStoreProperty(resource, true);
     }
 
     @Test
     public void testMissingMagentoStoreProperty() {
-        // Get page whose parent has the cq:magentoStore property in its jcr:content node
+        // Get page whose parent has the magentoStore property in its jcr:content node
         Resource resource = Mockito.spy(context.resourceResolver().getResource("/content/pageD"));
         testMagentoStoreProperty(resource, false);
     }
 
     @Test
+    public void testOldMagentoStoreProperty() {
+        // Get page which has the old cq:magentoStore property in its jcr:content node
+        Resource resource = Mockito.spy(context.resourceResolver().getResource("/content/pageE"));
+        testMagentoStoreProperty(resource, true);
+    }
+
+    @Test
+    public void testNewMagentoStoreProperty() {
+        // Get page which has both the new magentoStore property and old cq:magentoStore property
+        // in its jcr:content node and make sure the new one is prefered
+        Resource resource = Mockito.spy(context.resourceResolver().getResource("/content/pageF"));
+        testMagentoStoreProperty(resource, true);
+    }
+
+    @Test
     public void testError() {
-        // Get page which has the cq:magentoStore property in its jcr:content node
+        // Get page which has the magentoStore property in its jcr:content node
         Resource resource = Mockito.spy(context.resourceResolver().getResource("/content/pageA"));
         Mockito.when(resource.adaptTo(GraphqlClient.class)).thenReturn(null);
 

--- a/bundles/core/src/test/resources/context/jcr-content.json
+++ b/bundles/core/src/test/resources/context/jcr-content.json
@@ -4,7 +4,7 @@
     "jcr:content": {
       "jcr:language": "en_US",
       "jcr:primaryType": "cq:PageContent",
-      "cq:magentoStore": "my-store",
+      "magentoStore": "my-store",
       "root": {
         "responsivegrid": {
           "productteaser-simple": {
@@ -43,7 +43,7 @@
     "jcr:primaryType": "cq:Page",
     "jcr:content": {
       "jcr:primaryType": "cq:PageContent",
-      "cq:magentoStore": "my-store"
+      "magentoStore": "my-store"
     },
     "pageC": {
       "jcr:primaryType": "cq:Page",
@@ -56,6 +56,21 @@
     "jcr:primaryType": "cq:Page",
     "jcr:content": {
       "jcr:primaryType": "cq:PageContent"
+    }
+  },
+  "pageE": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "cq:magentoStore": "my-store"
+    }
+  },
+  "pageF": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "magentoStore": "my-store",
+      "cq:magentoStore": "old-store"
     }
   }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/catalogpage/v1/catalogpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/catalogpage/v1/catalogpage/_cq_dialog/.content.xml
@@ -3,25 +3,68 @@
     xmlns:jcr="http://www.jcp.org/jcr/1.0" 
     xmlns:nt="http://www.jcp.org/jcr/nt/1.0" 
     xmlns:cq="http://www.day.com/jcr/cq/1.0" 
-    xmlns:granite="http://www.adobe.com/jcr/granite/1.0" jcr:primaryType="nt:unstructured" jcr:title="Page" sling:resourceType="cq/gui/components/authoring/dialog" extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties,granite.contexthub.configuration,cq.siteadmin.admin.properties]" mode="edit" trackingFeature="cif-core-components:catalogpage:v1">
-    <content granite:class="cq-dialog-content-page" jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/container">
+    xmlns:granite="http://www.adobe.com/jcr/granite/1.0" 
+    jcr:primaryType="nt:unstructured" 
+    jcr:title="Page" 
+    sling:resourceType="cq/gui/components/authoring/dialog" 
+    extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties,granite.contexthub.configuration,cq.siteadmin.admin.properties]" 
+    mode="edit" 
+    trackingFeature="cif-core-components:catalogpage:v1">
+    <content granite:class="cq-dialog-content-page" 
+        jcr:primaryType="nt:unstructured" 
+        sling:resourceType="granite/ui/components/coral/foundation/container">
         <items jcr:primaryType="nt:unstructured">
-            <tabs granite:class="cq-siteadmin-admin-properties-tabs" jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/tabs" size="L">
+            <tabs granite:class="cq-siteadmin-admin-properties-tabs" 
+                jcr:primaryType="nt:unstructured" 
+                sling:resourceType="granite/ui/components/coral/foundation/tabs" 
+                size="L">
                 <items jcr:primaryType="nt:unstructured">
-                    <commerce cq:showOnCreate="{Boolean}true" jcr:primaryType="nt:unstructured" jcr:title="Commerce" sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns" sling:orderBefore="cloudservices">
+                    <commerce cq:showOnCreate="{Boolean}true" 
+                        jcr:primaryType="nt:unstructured" 
+                        jcr:title="Commerce" 
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns" 
+                        sling:orderBefore="cloudservices">
                         <items jcr:primaryType="nt:unstructured">
-                            <column jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/container">
+                            <column jcr:primaryType="nt:unstructured" 
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
-                                    <catalogsection jcr:primaryType="nt:unstructured" jcr:title="Catalog Landing Page" sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                    <magentoSection jcr:primaryType="nt:unstructured" 
+                                        jcr:title="Magento Store Configuration" 
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <showMainCategories cq:showOnCreate="{Boolean}true" jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/form/checkbox" fieldDescription="If checked the navigation includes the child categories of the category provided in the field 'Root category ID', otherwise the navigation includes the catalog landing page." name="./showMainCategories" renderReadOnly="{Boolean}true" text="Show main categories" value="true">
-                                                <granite:data jcr:primaryType="nt:unstructured" cq-msm-lockable="showMainCategories"/>
+                                            <storeview jcr:primaryType="nt:unstructured" 
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield" 
+                                                fieldDescription="Identifier to select Magento Store View. If empty, the default store will be used." 
+                                                fieldLabel="Store View" 
+                                                name="./magentoStore" 
+                                                renderReadOnly="{Boolean}false">
+                                                <granite:data jcr:primaryType="nt:unstructured" 
+                                                    cq-msm-lockable="magentoStore" />
+                                            </storeview>
+                                            <showMainCategories cq:showOnCreate="{Boolean}true" 
+                                                jcr:primaryType="nt:unstructured" 
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox" 
+                                                fieldDescription="If checked the navigation includes the child categories of the category provided in the field 'Root category ID', otherwise the navigation includes the catalog landing page." 
+                                                name="./showMainCategories" 
+                                                renderReadOnly="{Boolean}true" 
+                                                text="Show main categories" 
+                                                value="true">
+                                                <granite:data jcr:primaryType="nt:unstructured" 
+                                                    cq-msm-lockable="showMainCategories" />
                                             </showMainCategories>
-                                            <categoryId cq:showOnCreate="{Boolean}true" jcr:primaryType="nt:unstructured" sling:resourceType="commerce/gui/components/common/cifcategoryfield" fieldDescription="Select the root category to be used in navigation." fieldLabel="Root category ID" name="./magentoRootCategoryId" renderReadOnly="{Boolean}true" translateOptions="{Boolean}false">
-                                                <granite:data jcr:primaryType="nt:unstructured" cq-msm-lockable="magentoRootCategoryId"/>
+                                            <categoryId cq:showOnCreate="{Boolean}true" 
+                                                jcr:primaryType="nt:unstructured" 
+                                                sling:resourceType="commerce/gui/components/common/cifcategoryfield" 
+                                                fieldDescription="Select the root category to be used in navigation." 
+                                                fieldLabel="Root category ID" 
+                                                name="./magentoRootCategoryId" 
+                                                renderReadOnly="{Boolean}true" 
+                                                translateOptions="{Boolean}false">
+                                                <granite:data jcr:primaryType="nt:unstructured" 
+                                                    cq-msm-lockable="magentoRootCategoryId" />
                                             </categoryId>
                                         </items>
-                                    </catalogsection>
+                                    </magentoSection>
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -3,23 +3,56 @@
     xmlns:granite="http://www.adobe.com/jcr/granite/1.0" 
     xmlns:cq="http://www.day.com/jcr/cq/1.0" 
     xmlns:jcr="http://www.jcp.org/jcr/1.0" 
-    xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:primaryType="nt:unstructured" jcr:title="Page" sling:resourceType="cq/gui/components/authoring/dialog" extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties,granite.contexthub.configuration,cq.siteadmin.admin.properties]" mode="edit" trackingFeature="cif-core-components:page:v1">
-    <content granite:class="cq-dialog-content-page" jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/container">
+    xmlns:nt="http://www.jcp.org/jcr/nt/1.0" 
+    jcr:primaryType="nt:unstructured" 
+    jcr:title="Page" 
+    sling:resourceType="cq/gui/components/authoring/dialog" 
+    extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties,granite.contexthub.configuration,cq.siteadmin.admin.properties]" 
+    mode="edit" 
+    trackingFeature="cif-core-components:page:v1">
+    <content granite:class="cq-dialog-content-page" 
+        jcr:primaryType="nt:unstructured" 
+        sling:resourceType="granite/ui/components/coral/foundation/container">
         <items jcr:primaryType="nt:unstructured">
-            <tabs granite:class="cq-siteadmin-admin-properties-tabs" jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/tabs" size="L">
+            <tabs granite:class="cq-siteadmin-admin-properties-tabs" 
+                jcr:primaryType="nt:unstructured" 
+                sling:resourceType="granite/ui/components/coral/foundation/tabs" 
+                size="L">
                 <items jcr:primaryType="nt:unstructured">
-                    <commerce cq:showOnCreate="{Boolean}true" jcr:primaryType="nt:unstructured" jcr:title="Commerce" sling:orderBefore="cloudservices" sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                    <commerce cq:showOnCreate="{Boolean}true" 
+                        jcr:primaryType="nt:unstructured" 
+                        jcr:title="Commerce" 
+                        sling:orderBefore="cloudservices" 
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
                         <items jcr:primaryType="nt:unstructured">
-                            <column jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/container">
+                            <column jcr:primaryType="nt:unstructured" 
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
-                                    <graphqlsection jcr:primaryType="nt:unstructured" jcr:title="GraphQL Client Configuration" sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                    <graphqlsection jcr:primaryType="nt:unstructured" 
+                                        jcr:title="GraphQL Client Configuration" 
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <graphqlclient emptyOption="{Boolean}false" granite:id="cq-commerce-graphql-client" jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/form/select" fieldDescription="The GraphQL client instance. If this list is empty check the configurations of the CIF GraphQL Client Configuration service. " fieldLabel="GraphQL Client" name="./cq:graphqlClient" required="{Boolean}false">
-                                                <datasource jcr:primaryType="nt:unstructured" sling:resourceType="core/cif/components/page/v1/datasource/graphqlclients"/>
-                                                <granite:data jcr:primaryType="nt:unstructured" cq-msm-lockable="cq:graphqlClient"/>
+                                            <graphqlclient emptyOption="{Boolean}false" 
+                                                granite:id="cq-commerce-graphql-client" 
+                                                jcr:primaryType="nt:unstructured" 
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/select" 
+                                                fieldDescription="The GraphQL client instance. If this list is empty check the configurations of the CIF GraphQL Client Configuration service. " 
+                                                fieldLabel="GraphQL Client" 
+                                                name="./cq:graphqlClient" 
+                                                required="{Boolean}false">
+                                                <datasource jcr:primaryType="nt:unstructured" 
+                                                    sling:resourceType="core/cif/components/page/v1/datasource/graphqlclients" />
+                                                <granite:data jcr:primaryType="nt:unstructured" 
+                                                    cq-msm-lockable="cq:graphqlClient" />
                                             </graphqlclient>
-                                            <storeview jcr:primaryType="nt:unstructured" sling:resourceType="granite/ui/components/coral/foundation/form/textfield" fieldDescription="Identifier to select Magento Store View. If empty, the default store will be used." fieldLabel="Store View" name="./cq:magentoStore" renderReadOnly="{Boolean}false">
-                                                <granite:data jcr:primaryType="nt:unstructured" cq-msm-lockable="cq:magentoStore"/>
+                                            <storeview jcr:primaryType="nt:unstructured" 
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield" 
+                                                fieldDescription="Identifier to select Magento Store View. If empty, the default store will be used." 
+                                                fieldLabel="Store View" 
+                                                name="./magentoStore" 
+                                                renderReadOnly="{Boolean}false">
+                                                <granite:data jcr:primaryType="nt:unstructured" 
+                                                    cq-msm-lockable="magentoStore" />
                                             </storeview>
                                         </items>
                                     </graphqlsection>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -28,23 +28,10 @@
                             <column jcr:primaryType="nt:unstructured" 
                                 sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
-                                    <graphqlsection jcr:primaryType="nt:unstructured" 
-                                        jcr:title="GraphQL Client Configuration" 
+                                    <magentoSection jcr:primaryType="nt:unstructured" 
+                                        jcr:title="Magento Store Configuration" 
                                         sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <graphqlclient emptyOption="{Boolean}false" 
-                                                granite:id="cq-commerce-graphql-client" 
-                                                jcr:primaryType="nt:unstructured" 
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/select" 
-                                                fieldDescription="The GraphQL client instance. If this list is empty check the configurations of the CIF GraphQL Client Configuration service. " 
-                                                fieldLabel="GraphQL Client" 
-                                                name="./cq:graphqlClient" 
-                                                required="{Boolean}false">
-                                                <datasource jcr:primaryType="nt:unstructured" 
-                                                    sling:resourceType="core/cif/components/page/v1/datasource/graphqlclients" />
-                                                <granite:data jcr:primaryType="nt:unstructured" 
-                                                    cq-msm-lockable="cq:graphqlClient" />
-                                            </graphqlclient>
                                             <storeview jcr:primaryType="nt:unstructured" 
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield" 
                                                 fieldDescription="Identifier to select Magento Store View. If empty, the default store will be used." 
@@ -55,7 +42,7 @@
                                                     cq-msm-lockable="magentoStore" />
                                             </storeview>
                                         </items>
-                                    </graphqlsection>
+                                    </magentoSection>
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -37,7 +37,8 @@
                                                 fieldDescription="Identifier to select Magento Store View. If empty, the default store will be used." 
                                                 fieldLabel="Store View" 
                                                 name="./magentoStore" 
-                                                renderReadOnly="{Boolean}false">
+                                                renderReadOnly="{Boolean}false" 
+                                                cq:showOnCreate="{Boolean}true">
                                                 <granite:data jcr:primaryType="nt:unstructured" 
                                                     cq-msm-lockable="magentoStore" />
                                             </storeview>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/rootpage/v1/rootpage/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/rootpage/v1/rootpage/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" 
+    xmlns:cq="http://www.day.com/jcr/cq/1.0" 
+    xmlns:jcr="http://www.jcp.org/jcr/1.0" 
+    cq:icon="page" 
+    jcr:primaryType="cq:Component" 
+    jcr:title="CIF Core Site Root Page" 
+    sling:resourceSuperType="core/cif/components/structure/page/v1/page" 
+    componentGroup=".hidden" />

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/rootpage/v1/rootpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/rootpage/v1/rootpage/_cq_dialog/.content.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" 
+    xmlns:jcr="http://www.jcp.org/jcr/1.0" 
+    xmlns:nt="http://www.jcp.org/jcr/nt/1.0" 
+    xmlns:cq="http://www.day.com/jcr/cq/1.0" 
+    xmlns:granite="http://www.adobe.com/jcr/granite/1.0" 
+    jcr:primaryType="nt:unstructured" 
+    jcr:title="Page" 
+    sling:resourceType="cq/gui/components/authoring/dialog" 
+    extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties,granite.contexthub.configuration,cq.siteadmin.admin.properties]" 
+    mode="edit" 
+    trackingFeature="cif-core-components:rootpage:v1">
+    <content granite:class="cq-dialog-content-page" 
+        jcr:primaryType="nt:unstructured" 
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs granite:class="cq-siteadmin-admin-properties-tabs" 
+                jcr:primaryType="nt:unstructured" 
+                sling:resourceType="granite/ui/components/coral/foundation/tabs" 
+                size="L">
+                <items jcr:primaryType="nt:unstructured">
+                    <commerce cq:showOnCreate="{Boolean}true" 
+                        jcr:primaryType="nt:unstructured" 
+                        jcr:title="Commerce" 
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns" 
+                        sling:orderBefore="cloudservices">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column jcr:primaryType="nt:unstructured" 
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured" 
+                                    sling:orderBefore="magentoSection">
+                                    <graphqlsection jcr:primaryType="nt:unstructured" 
+                                        jcr:title="GraphQL Client Configuration" 
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset" 
+                                        sling:orderBefore="cloudservices">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <graphqlclient emptyOption="{Boolean}false" 
+                                                granite:id="cq-commerce-graphql-client" 
+                                                jcr:primaryType="nt:unstructured" 
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/select" 
+                                                fieldDescription="The GraphQL client instance. If this list is empty check the configurations of the CIF GraphQL Client Configuration service. " 
+                                                fieldLabel="GraphQL Client" 
+                                                name="./cq:graphqlClient" 
+                                                required="{Boolean}false">
+                                                <datasource jcr:primaryType="nt:unstructured" 
+                                                    sling:resourceType="core/cif/components/page/v1/datasource/graphqlclients" />
+                                                <granite:data jcr:primaryType="nt:unstructured" 
+                                                    cq-msm-lockable="cq:graphqlClient" />
+                                            </graphqlclient>
+                                        </items>
+                                    </graphqlsection>
+                                </items>
+                            </column>
+                        </items>
+                    </commerce>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/rootpage/v1/rootpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/rootpage/v1/rootpage/_cq_dialog/.content.xml
@@ -27,12 +27,11 @@
                         <items jcr:primaryType="nt:unstructured">
                             <column jcr:primaryType="nt:unstructured" 
                                 sling:resourceType="granite/ui/components/coral/foundation/container">
-                                <items jcr:primaryType="nt:unstructured" 
-                                    sling:orderBefore="magentoSection">
+                                <items jcr:primaryType="nt:unstructured">
                                     <graphqlsection jcr:primaryType="nt:unstructured" 
                                         jcr:title="GraphQL Client Configuration" 
                                         sling:resourceType="granite/ui/components/coral/foundation/form/fieldset" 
-                                        sling:orderBefore="cloudservices">
+                                        sling:orderBefore="magentoSection">
                                         <items jcr:primaryType="nt:unstructured">
                                             <graphqlclient emptyOption="{Boolean}false" 
                                                 granite:id="cq-commerce-graphql-client" 
@@ -41,7 +40,8 @@
                                                 fieldDescription="The GraphQL client instance. If this list is empty check the configurations of the CIF GraphQL Client Configuration service. " 
                                                 fieldLabel="GraphQL Client" 
                                                 name="./cq:graphqlClient" 
-                                                required="{Boolean}false">
+                                                required="{Boolean}false" 
+                                                cq:showOnCreate="{Boolean}true">
                                                 <datasource jcr:primaryType="nt:unstructured" 
                                                     sling:resourceType="core/cif/components/page/v1/datasource/graphqlclients" />
                                                 <granite:data jcr:primaryType="nt:unstructured" 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the MSM rollout of multi site/store content structures of the store view property. The old property (`cq:magentoStore`) was excluded by MSM rollout and was changed to `magentoStore`. The old property still can be used (for content structures not using MSM) as fall back.

The`cq:graphqlClient` property is now only editable on the site root page to not run into MSM rollout issues and not confuse authors and different properties being available at different levels.

For that, it introduces a "root" page which is the only page of the site structure that has `cq:graphqlClient` property. All child pages will only have `magentoStore`. Additionally the correct `cq:allowedTemplates` are set (in separate CIF Archetype PR https://github.com/adobe/aem-cif-project-archetype/pull/64).

A sample content structure can look like this:
```
- /content/venia
    - /language-master (root page template with cq:graphqlClient prop)
        -/en (landing page template with magentoStore prop)
        -/de (landing page template with magentoStore prop)
    - /us (root page template with cq:graphqlClient prop)
        -/en (landing page template with magentoStore prop)
            -/products (any template with magentoStore prop and others)
            -/search
```

The wiki documenting the page properties must be updated once this is merged.

## Related Issue

CIF-1149

## How Has This Been Tested?

Intense manual tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
