### PR TITLE
CIF-1168 - [Build] Use the production build of React Components upon …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             node -v
             npm -v
             npm install
-            npm run webpack:build
+            npm run webpack:dev
           working_directory: ./ui.apps
       - run:
           name: Run Unit Tests (Karma)

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -106,6 +106,10 @@
         <slf4j.version>1.7.6</slf4j.version>
 
         <jacoco.version>0.7.9</jacoco.version>
+        
+        <!-- By default, webpack will build in development mode -->
+        <webpack:prod>false</webpack:prod>
+        <webpack:dev>true</webpack:dev>
     </properties>
 
     <!-- ====================================================================== -->
@@ -782,6 +786,11 @@
                     <value>true</value>
                 </property>
             </activation>
+            <properties>
+                <!-- When releasing, webpack will build in production mode -->
+                <webpack:prod>true</webpack:prod>
+                <webpack:dev>false</webpack:dev>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/react-components/package.json
+++ b/react-components/package.json
@@ -10,9 +10,10 @@
   },
   "module": "dist/index.js",
   "scripts": {
-    "prepare": "rm -rf ./dist && npm run build",
+    "prepare": "rm -rf ./dist",
     "lint": "eslint 'src/**/*.js'",
-    "build": "webpack",
+    "webpack:dev": "webpack --mode=development",
+    "webpack:prod": "webpack --mode=production",
     "test": "npm run lint && npm run prettier:check && jest --coverage",
     "ci": "npm run lint && npm run prettier:check && jest --ci --runInBand --coverage",
     "test:watch": "npm run lint && jest --watch",

--- a/react-components/pom.xml
+++ b/react-components/pom.xml
@@ -61,6 +61,26 @@
                         </goals>
                     </execution>
                     <execution>
+                        <id>npm-webpack-development</id> <!-- webpack development mode -->
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${webpack:prod}</skip>
+                            <arguments>run webpack:dev</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-webpack-production</id> <!-- webpack production mode -->
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${webpack:dev}</skip>
+                            <arguments>run webpack:prod</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>npm-module-link</id> <!-- Ignore npm scripts to avoid again executing 'prepare' -->
                         <goals>
                             <goal>npm</goal>

--- a/react-components/webpack.config.js
+++ b/react-components/webpack.config.js
@@ -80,7 +80,7 @@ module.exports = {
     },
     plugins: [new CleanWebpackPlugin()],
     devtool: 'source-map',
-    mode: process.env.NODE_ENV || 'development',
+    mode: 'development',
     resolve: {
         alias: {
             react: path.resolve(__dirname, './node_modules/react'),

--- a/ui.apps/package.json
+++ b/ui.apps/package.json
@@ -10,7 +10,8 @@
     "karma:debug": "karma start --single-run=false --browsers Chrome --debug karma.conf.js",
     "prettier:check": "prettier --check '{src,test}/**/*.{js,css}' --config ./.prettierrc",
     "prettier:fix": "prettier --write '{src,test}/**/*.{js,css}' --config ./.prettierrc",
-    "webpack:build": "webpack --config webpack.config.js --env.production --mode development"
+    "webpack:dev": "webpack --env.production --mode=development",
+    "webpack:prod": "webpack --env.production --mode=production"
   },
   "author": "Adobe",
   "repository": {

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -174,12 +174,23 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>npm-webpack-build</id>
+                        <id>npm-webpack-development</id> <!-- webpack development mode -->
                         <goals>
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>run webpack:build</arguments>
+                            <skip>${webpack:prod}</skip>
+                            <arguments>run webpack:dev</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-webpack-production</id> <!-- webpack production mode -->
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${webpack:dev}</skip>
+                            <arguments>run webpack:prod</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -202,13 +213,25 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>npm-webpack-build-react-components</id>
+                        <id>npm-webpack-development-react-components</id>
                         <goals>
                             <goal>npm</goal>
                         </goals>
                         <configuration>
+                            <skip>${webpack:prod}</skip>
                             <workingDirectory>${basedir}/src/main/javascript/react-components/</workingDirectory>
-                            <arguments>run build</arguments>
+                            <arguments>run webpack:dev</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-webpack-production-react-components</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${webpack:dev}</skip>
+                            <workingDirectory>${basedir}/src/main/javascript/react-components/</workingDirectory>
+                            <arguments>run webpack:prod</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/.content.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          jcr:primaryType="cq:ClientLibraryFolder"
-          allowProxy="{Boolean}true"
-          categories="[core.cif.components.common]"/>
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.cif.components.common]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/react-components/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/react-components/.content.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          jcr:primaryType="cq:ClientLibraryFolder"
-          allowProxy="{Boolean}true"
-          categories="[core.cif.components.react]"/>
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.cif.components.react]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/.content.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-          xmlns:cq="http://www.day.com/jcr/cq/1.0"
-          xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
-          jcr:primaryType="cq:ClientLibraryFolder"
-          allowProxy="{Boolean}true"
-          categories="[core.cif.components.product.v1]"
-          dependencies="[core.cif.components.common]">
-</jcr:root>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.cif.components.product.v1]"
+    dependencies="[core.cif.components.common]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/clientlibs/.content.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[core.cif.components.productcarousel.v1]"/>
+    categories="[core.cif.components.productcarousel.v1]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/clientlibs/.content.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[core.cif.components.productlist.v1]"/>
+    categories="[core.cif.components.productlist.v1]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/.content.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-          xmlns:cq="http://www.day.com/jcr/cq/1.0"
-          xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
-          jcr:primaryType="cq:ClientLibraryFolder"
-          allowProxy="{Boolean}true"
-          categories="[core.cif.components.productteaser.v1]"
-          dependencies="[core.cif.components.common]">
-</jcr:root>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.cif.components.productteaser.v1]"
+    dependencies="[core.cif.components.common]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/searchbar/v1/searchbar/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/searchbar/v1/searchbar/clientlibs/.content.xml
@@ -3,4 +3,5 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[core.cif.components.searchbar.v1]"
-    dependencies="[core.cif.components.theme]"/>
+    dependencies="[core.cif.components.theme]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/navigation/v1/navigation/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/navigation/v1/navigation/clientlibs/.content.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          jcr:primaryType="cq:ClientLibraryFolder"
-          allowProxy="{Boolean}true"
-          categories="[core.cif.components.navigation.v1]"/>
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.cif.components.navigation.v1]"
+    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/javascript/react-components/package.json
+++ b/ui.apps/src/main/javascript/react-components/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack",
+    "webpack:dev": "webpack --mode=development",
+    "webpack:prod": "webpack --mode=production",
     "lint": "eslint './src/**/*.js'",
     "build:clientlib": "npm run build && node build-scripts/postbuild.js"
   },

--- a/ui.apps/src/main/javascript/react-components/webpack.config.js
+++ b/ui.apps/src/main/javascript/react-components/webpack.config.js
@@ -41,5 +41,5 @@ module.exports = {
         }
     },
     devtool: 'source-map',
-    mode: process.NODE_ENV || 'development'
+    mode: 'development'
 };


### PR DESCRIPTION
…release

- added npm scripts to run webpack either in development or production mode
- enabled webpack production mode in the maven release-sign-artifacts profile
- disabled minification of the react-components clientlib in AEM

## Related Issue

https://github.com/adobe/commerce-cif-connector/issues/86

## How Has This Been Tested?

Locally tested in AEM, with minification activated in the "Adobe Granite HTML Library Manager" config.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
