### PR TITLE
CIF-1226 - Update Product Filters in Components for Magento 2.3.4 Schema

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -500,7 +500,7 @@
         <dependency>
             <groupId>com.adobe.commerce.cif</groupId>
             <artifactId>magento-graphql</artifactId>
-            <version>4.0.0-magento233</version>
+            <version>5.0.0-magento234</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductRetriever.java
@@ -19,9 +19,9 @@ import java.util.List;
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
-import com.adobe.cq.commerce.magento.graphql.FilterTypeInput;
+import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Operations;
-import com.adobe.cq.commerce.magento.graphql.ProductFilterInput;
+import com.adobe.cq.commerce.magento.graphql.ProductAttributeFilterInput;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQueryDefinition;
 import com.adobe.cq.commerce.magento.graphql.ProductPricesQueryDefinition;
@@ -60,8 +60,8 @@ class ProductRetriever extends AbstractProductRetriever {
     @Override
     protected String generateQuery(String slug) {
         // Override the method here to first use a slug instead of SKU and also add the store config query
-        FilterTypeInput input = new FilterTypeInput().setEq(slug);
-        ProductFilterInput filter = new ProductFilterInput().setUrlKey(input);
+        FilterEqualTypeInput slugFilter = new FilterEqualTypeInput().setEq(slug);
+        ProductAttributeFilterInput filter = new ProductAttributeFilterInput().setUrlKey(slugFilter);
         QueryQuery.ProductsArgumentsDefinition searchArgs = s -> s.filter(filter);
 
         // GraphQL query

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsRetriever.java
@@ -19,9 +19,9 @@ import java.util.List;
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductsRetriever;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableProductQueryDefinition;
-import com.adobe.cq.commerce.magento.graphql.FilterTypeInput;
+import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Operations;
-import com.adobe.cq.commerce.magento.graphql.ProductFilterInput;
+import com.adobe.cq.commerce.magento.graphql.ProductAttributeFilterInput;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQueryDefinition;
 import com.adobe.cq.commerce.magento.graphql.ProductPricesQueryDefinition;
@@ -61,8 +61,8 @@ class RelatedProductsRetriever extends AbstractProductsRetriever {
 
     @Override
     protected String generateQuery(List<String> identifiers) {
-        FilterTypeInput input = new FilterTypeInput().setEq(identifiers.get(0));
-        ProductFilterInput filter = new ProductFilterInput();
+        FilterEqualTypeInput input = new FilterEqualTypeInput().setEq(identifiers.get(0));
+        ProductAttributeFilterInput filter = new ProductAttributeFilterInput();
         if (ProductIdType.SKU.equals(productIdType)) {
             filter.setSku(input);
         } else {

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductRetriever.java
@@ -19,9 +19,9 @@ import java.util.function.Consumer;
 
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
-import com.adobe.cq.commerce.magento.graphql.FilterTypeInput;
+import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Operations;
-import com.adobe.cq.commerce.magento.graphql.ProductFilterInput;
+import com.adobe.cq.commerce.magento.graphql.ProductAttributeFilterInput;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQuery;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQueryDefinition;
@@ -148,8 +148,8 @@ public abstract class AbstractProductRetriever extends AbstractRetriever {
      * @return GraphQL query as string
      */
     protected String generateQuery(String identifier) {
-        FilterTypeInput input = new FilterTypeInput().setEq(identifier);
-        ProductFilterInput filter = new ProductFilterInput().setSku(input);
+        FilterEqualTypeInput skuFilter = new FilterEqualTypeInput().setEq(identifier);
+        ProductAttributeFilterInput filter = new ProductAttributeFilterInput().setSku(skuFilter);
         QueryQuery.ProductsArgumentsDefinition searchArgs = s -> s.filter(filter);
 
         ProductsQueryDefinition queryArgs = q -> q.items(generateProductQuery());

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductsRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductsRetriever.java
@@ -18,9 +18,9 @@ import java.util.function.Consumer;
 
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
-import com.adobe.cq.commerce.magento.graphql.FilterTypeInput;
+import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Operations;
-import com.adobe.cq.commerce.magento.graphql.ProductFilterInput;
+import com.adobe.cq.commerce.magento.graphql.ProductAttributeFilterInput;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQuery;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQueryDefinition;
@@ -126,8 +126,8 @@ public abstract class AbstractProductsRetriever extends AbstractRetriever {
      * @return GraphQL query as string
      */
     protected String generateQuery(List<String> identifiers) {
-        FilterTypeInput input = new FilterTypeInput().setIn(identifiers);
-        ProductFilterInput filter = new ProductFilterInput().setSku(input);
+        FilterEqualTypeInput skuFilter = new FilterEqualTypeInput().setIn(identifiers);
+        ProductAttributeFilterInput filter = new ProductAttributeFilterInput().setSku(skuFilter);
         QueryQuery.ProductsArgumentsDefinition searchArgs = s -> s.filter(filter);
 
         ProductsQueryDefinition queryArgs = q -> q.items(generateProductQuery());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the Magento 2.3.4 schema, the product query no longer accepts `ProductFilterInput` instances. All occurrences needed to be replaced with the new `ProductAttributeFilterInput` since otherwise the build fails. 

## How Has This Been Tested?

* Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
