### PR TITLE
CIF-1231 - fix featured category placeholder display

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImpl.java
@@ -102,14 +102,14 @@ public class FeaturedCategoryListImpl implements FeaturedCategoryList {
                 Asset overrideAsset = assetResource.adaptTo(Asset.class);
                 assetOverride.put(categoryId, overrideAsset);
             }
-        }
 
-        if (categoryIds.size() > 0) {
-            MagentoGraphqlClient magentoGraphqlClient = MagentoGraphqlClient.create(resource);
-            categoriesRetriever = new CategoriesRetriever(magentoGraphqlClient);
-            categoriesRetriever.setIdentifiers(categoryIds);
-        } else {
-            LOGGER.debug("There are no categories configured for CategoryList Component.");
+            if (categoryIds.size() > 0) {
+                MagentoGraphqlClient magentoGraphqlClient = MagentoGraphqlClient.create(resource);
+                categoriesRetriever = new CategoriesRetriever(magentoGraphqlClient);
+                categoriesRetriever.setIdentifiers(categoryIds);
+            } else {
+                LOGGER.debug("There are no categories configured for CategoryList Component.");
+            }
         }
     }
 
@@ -136,6 +136,11 @@ public class FeaturedCategoryListImpl implements FeaturedCategoryList {
             }
         }
         return categories;
+    }
+
+    @Override
+    public boolean isConfigured() {
+        return resource.getChild(ITEMS_PROP) != null;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/categorylist/FeaturedCategoryList.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/categorylist/FeaturedCategoryList.java
@@ -41,4 +41,10 @@ public interface FeaturedCategoryList {
      */
     AbstractCategoriesRetriever getCategoriesRetriever();
 
+    /**
+     * Returns true if the component is correctly configured, false otherwise.
+     *
+     * @return true or false
+     */
+    boolean isConfigured();
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImplTest.java
@@ -121,6 +121,7 @@ public class FeaturedCategoryListImplTest {
     @Test
     public void verifyModel() {
         Assert.assertNotNull(slingModelConfigured);
+        Assert.assertTrue(slingModelConfigured.isConfigured());
         List<CategoryTree> list = slingModelConfigured.getCategories();
         Assert.assertNotNull(list);
         Assert.assertEquals(list.size(), 3);
@@ -128,6 +129,8 @@ public class FeaturedCategoryListImplTest {
 
     @Test
     public void verifyCategory() {
+        Assert.assertNotNull(slingModelConfigured);
+        Assert.assertTrue(slingModelConfigured.isConfigured());
         categories = slingModelConfigured.getCategories();
         Assert.assertNotNull(categories);
         Assert.assertEquals(categories.get(0).getName(), TEST_CATEGORY_NAME);
@@ -146,6 +149,7 @@ public class FeaturedCategoryListImplTest {
     public void verifyNotConfigired() {
         Assert.assertNotNull(slingModelNotConfigured);
         Assert.assertNull(slingModelNotConfigured.getCategoriesRetriever());
+        Assert.assertFalse(slingModelNotConfigured.isConfigured());
         categories = slingModelNotConfigured.getCategories();
         Assert.assertNotNull(categories);
         Assert.assertEquals(categories.size(), 0);

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/featuredcategorylist/v1/featuredcategorylist/featuredcategorylist.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/featuredcategorylist/v1/featuredcategorylist/featuredcategorylist.html
@@ -15,8 +15,9 @@
 */-->
 
 <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
-     data-sly-use.category="com.adobe.cq.commerce.core.components.models.categorylist.FeaturedCategoryList">
-    <sly data-sly-test.isConfigured="${category.categories.size}">
+     data-sly-use.category="com.adobe.cq.commerce.core.components.models.categorylist.FeaturedCategoryList"
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html">
+    <sly data-sly-test.hasCategories="${category.categories.size}">
     <div class="cmp-categorylist">
         <div class="cmp-categorylist__header">
             <h2 class="cmp-categorylist__title">
@@ -33,10 +34,7 @@
         </div>
     </div>
     </sly>
-    <div data-sly-test="${!isConfigured}" class="placeholder__empty">
-        <strong>${'Featured Category List' @ i18n}</strong><br>
-        <p>${'Please configure categories' @ i18n}</p>
-    </div>
+    <sly data-sly-call="${templates.placeholder @ isEmpty = !category.isConfigured, emptyTextAppend = 'Please configure categories'}" />
+    <sly data-sly-call="${templates.placeholder @ isEmpty = category.isConfigured && !hasCategories, emptyTextAppend = 'Configured, no categories were loaded'}" />
 </sly>
 </sly>
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix featured category placeholder display in publish mode. The component was switched to the WCM core components placeholder template and displays two different placeholders, based on the state. The component distinguishes between configured vs. not configured and configured but no category data available.

Author (edit): placeholder if not configured or configured but no category data
Author (preview) & publish: no place holder

## Related Issue

CIF-1231

## Motivation and Context

Don't display placeholders on publish and unify placeholder usage.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
