### PR TITLE
CIF-1229 - Release fails after npm publish

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -375,7 +375,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <!-- Maven Resources Plugin -->
                 <plugin>

--- a/react-components/package.json
+++ b/react-components/package.json
@@ -10,7 +10,6 @@
   },
   "module": "dist/index.js",
   "scripts": {
-    "prepare": "rm -rf ./dist",
     "lint": "eslint 'src/**/*.js'",
     "webpack:dev": "webpack --mode=development",
     "webpack:prod": "webpack --mode=production",

--- a/react-components/pom.xml
+++ b/react-components/pom.xml
@@ -55,7 +55,7 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>npm-install</id> <!-- Will also execute the 'prepare' script from package.json -->
+                        <id>npm-install</id>
                         <goals>
                             <goal>npm</goal>
                         </goals>
@@ -81,12 +81,12 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>npm-module-link</id> <!-- Ignore npm scripts to avoid again executing 'prepare' -->
+                        <id>npm-module-link</id>
                         <goals>
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>link --ignore-scripts</arguments>
+                            <arguments>link</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -119,6 +119,17 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>dist</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
             </plugin>
             
         </plugins>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -239,7 +239,6 @@
 
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>3.0.0</version>
                 <configuration>
                     <filesets>
                         <fileset>


### PR DESCRIPTION
- fix release, dist/ folder should not be deleted
- "moved" npm prepare script to maven clean plugin

## Description

`npm publish` calls the `prepare` script: this actually deleted the `dist` folder so it broke the webpack build and also makes the released modules unusable because the `package.json` file specifies that the module is in `dist/index.js` but this was deleted by the release job. 

## How Has This Been Tested?

Locally tested by changing the POM to do `npm publish --dry-run`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
