### PR TITLE
CIF-1237 - Use generic authoring placeholder of WCM Core Components for all CIF Components

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractCategoriesRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractCategoriesRetriever.java
@@ -138,7 +138,9 @@ public abstract class AbstractCategoriesRetriever extends AbstractRetriever {
         for (String identifier : identifiers) {
             String alias = "category__category_" + identifier;
             CategoryTree category = (CategoryTree) rootQuery.get(alias);
-            categories.add(category);
+            if (category != null) {
+                categories.add(category);
+            }
         }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImplTest.java
@@ -119,6 +119,7 @@ public class FeaturedCategoryListImplTest {
         Assert.assertTrue(slingModelConfigured.isConfigured());
         categories = slingModelConfigured.getCategories();
         Assert.assertNotNull(categories);
+        categories.stream().forEach(c -> Assert.assertNotNull(c));
         Assert.assertEquals(categories.get(0).getName(), TEST_CATEGORY_NAME);
         Assert.assertEquals(categories.get(0).getImage(), TEST_IMAGE_URL);
         Assert.assertEquals(categories.get(0).getPath(), String.format("%s.%s.html", CATEGORY_PAGE, TEST_CATEGORY));

--- a/bundles/core/src/test/resources/context/jcr-content.json
+++ b/bundles/core/src/test/resources/context/jcr-content.json
@@ -91,7 +91,10 @@
                 "categoryId": "7",
                 "asset": "invalid-asset"
               },
-              "item3": {}
+              "item3": {},
+              "item4": {
+                "categoryId": "9999"
+              }
             }
           },
           "featuredcategorylist2": {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/featuredcategorylist/v1/featuredcategorylist/featuredcategorylist.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/featuredcategorylist/v1/featuredcategorylist/featuredcategorylist.html
@@ -34,7 +34,7 @@
         </div>
     </div>
     </sly>
-    <sly data-sly-call="${templates.placeholder @ isEmpty = !category.isConfigured, emptyTextAppend = 'Please configure categories'}" />
+    <sly data-sly-call="${templates.placeholder @ isEmpty = !category.isConfigured}" />
     <sly data-sly-call="${templates.placeholder @ isEmpty = category.isConfigured && !hasCategories, emptyTextAppend = 'Configured, no categories were loaded'}" />
 </sly>
 </sly>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/productcarousel.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/productcarousel.html
@@ -14,25 +14,22 @@
 <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-call="${clientlib.all @ categories='core.cif.components.productcarousel.v1'}"
      data-sly-use.carousel="${'com.adobe.cq.commerce.core.components.models.productcarousel.ProductCarousel' @productSkuList=properties.product}"
-/>
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     data-sly-use.productTpl="productcard.html" />
 
-<sly data-sly-test="${!carousel.isConfigured}">
-    <div class="placeholder__empty productcarousel__title" data-sly-text="${component.title}"></div>
-</sly>
-
-<sly data-sly-use.productTpl="productcard.html" data-sly-test="${carousel.isConfigured && (carousel.products || !wcmmode.disabled)}">
+<sly data-sly-test.hasProducts="${carousel.isConfigured && carousel.products}">
     <div data-comp-is="productcarousel">
-        <sly data-sly-test.hasProducts="${carousel.products}">
-	        <button data-carousel-action='prev' class="productcarousel__btn productcarousel__btn--prev" type="button"></button>
-	        <div class="productcarousel productcarousel__root">
-	            <div class="productcarousel__parent" >
-	                <div class="productcarousel__cardscontainer" data-sly-list.product=${carousel.products}>
-	                    <sly data-sly-call="${productTpl.productcard @ product=product}"></sly>
-	                </div>
-	            </div>
-	        </div>
-	        <button data-carousel-action='next' class="productcarousel__btn productcarousel__btn--next" type="button"></button>
-        </sly>
-        <div class="placeholder__empty productcarousel__title" data-sly-test="${!hasProducts}">${'No products to display.' @ i18n}</div>
+        <button data-carousel-action='prev' class="productcarousel__btn productcarousel__btn--prev" type="button"></button>
+        <div class="productcarousel productcarousel__root">
+            <div class="productcarousel__parent" >
+                <div class="productcarousel__cardscontainer" data-sly-list.product=${carousel.products}>
+                    <sly data-sly-call="${productTpl.productcard @ product=product}"></sly>
+                </div>
+            </div>
+        </div>
+        <button data-carousel-action='next' class="productcarousel__btn productcarousel__btn--next" type="button"></button>
     </div>
 </sly>
+
+<sly data-sly-call="${templates.placeholder @ isEmpty = !carousel.isConfigured}" />
+<sly data-sly-call="${templates.placeholder @ isEmpty = carousel.isConfigured && !hasProducts, emptyTextAppend = 'Configured, but no products to display'}" />

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/README.md
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/README.md
@@ -55,7 +55,6 @@ BLOCK category
     ELEMENT category__root-message
     ELEMENT category__title
     ELEMENT category__pagination
-    ELEMENT category__placeholder
     ELEMENT category__categoryTitle
     ELEMENT category__image
     

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
@@ -15,31 +15,23 @@
 */-->
 
 <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
-     data-sly-use.product="com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser"
-     data-sly-use.actionsTpl="actions.html">
-    <sly data-sly-call="${clientlib.all @ categories='core.cif.components.productteaser.v1'}"></sly>
-    <sly data-sly-test.ispropavailable="${properties.selection}">
-        <div data-sly-test.isvalid="${product.url}" class="item__root" data-cmp-is="productteaser">
-            <a class="item__images" href=${product.url}>
-                <img class="item__image" width="100%" height="100%"
-                     src="${product.image}" alt="${product.image}"/>
-            </a>
-            <a class="item__name" href=${product.url}><span>${product.name}</span></a>
-            <sly data-sly-use.template="core/cif/components/commons/v1/price.html"
-                 data-sly-call="${template.price @ priceRange=product.priceRange, displayYouSave=false}"></sly>
-            <sly data-sly-call="${actionsTpl.actions @ product=product}"></sly>
-        </div>
-        <!--/* Condition if the product is not available, or invalid sku provided */-->
-        <div class="blank-placeholder" data-sly-test=${!isvalid}>
-            <strong>${'Product Teaser' @ i18n} <br> ${'Incorrect Configuration. Select a Magento Product.' @ i18n}</strong>
-        </div>
-    </sly>
-    <!--/* Condition for no product configured and no property value available */-->
-    <div data-sly-test=${!ispropavailable} class="blank-placeholder">
-        <strong>${'Product Teaser' @ i18n}</strong><br>
-        <p>${'Configuration options' @ i18n}: </p>
-        <p> 1.${'Use dialog to choose Magento Products' @ i18n} </p>
-        <p> 2.${'Drag and drop a Magento product from assets sidebar at this area' @ i18n} </p>
-        <p> 3.${'You can also drag and drop Magento product from sidebar direclty in parsys and it will render the teaser' @ i18n} </p>
+    data-sly-use.product="com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser"
+    data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+    data-sly-use.actionsTpl="actions.html"
+    data-sly-test.isConfigured="${properties.selection}"
+    data-sly-test.hasProduct="${product.url}">
+    <sly data-sly-call="${clientlib.all @ categories='core.cif.components.productteaser.v1'}" />
+
+    <div data-sly-test="${isConfigured && hasProduct}" class="item__root" data-cmp-is="productteaser">
+        <a class="item__images" href=${product.url}>
+            <img class="item__image" width="100%" height="100%" src="${product.image}" alt="${product.image}" />
+        </a>
+        <a class="item__name" href=${product.url}><span>${product.name}</span></a>
+        <sly data-sly-use.template="core/cif/components/commons/v1/price.html"
+            data-sly-call="${template.price @ priceRange=product.priceRange, displayYouSave=false}"/>
+        <sly data-sly-call="${actionsTpl.actions @ product=product}"/>
     </div>
 </sly>
+
+<sly data-sly-call="${templates.placeholder @ isEmpty = !isConfigured}" />
+<sly data-sly-call="${templates.placeholder @ isEmpty = isConfigured && !hasProduct, emptyTextAppend = 'Configured, but no product to display'}" />

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/searchresults/v1/searchresults/README.md
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/searchresults/v1/searchresults/README.md
@@ -43,7 +43,6 @@ BLOCK category
     ELEMENT category__root-message
     ELEMENT category__title
     ELEMENT category__pagination
-    ELEMENT category__placeholder
     ELEMENT category__categoryTitle
     ELEMENT category__image
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use generic authoring placeholder of WCM Core Components for all CIF Core Components which have custom placeholders today and used by authors.
Corresponding Archetype PR https://github.com/adobe/aem-cif-project-archetype/pull/89 to clean up the obsolete CSS.

## Related Issue

CIF-1237

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
