### PR TITLE
CIF-1314 - Product list doesn't display product without small image

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
@@ -45,6 +45,7 @@ import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductsRe
 import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableProduct;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableVariant;
+import com.adobe.cq.commerce.magento.graphql.ProductImage;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.SimpleProduct;
 import com.day.cq.wcm.api.Page;
@@ -144,12 +145,13 @@ public class ProductCarouselImpl implements ProductCarousel {
 
                 try {
                     Price price = new PriceImpl(product.getPriceRange(), locale);
+                    ProductImage thumbnail = product.getThumbnail();
                     carouselProductList.add(new ProductListItemImpl(
                         skus.getLeft(),
                         slug,
                         product.getName(),
                         price,
-                        product.getThumbnail().getUrl(),
+                        thumbnail == null ? null : thumbnail.getUrl(),
                         productPage,
                         skus.getRight(),
                         request));

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
@@ -44,6 +44,7 @@ import com.adobe.cq.commerce.core.components.models.productlist.ProductList;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractCategoryRetriever;
 import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.magento.graphql.CategoryProducts;
+import com.adobe.cq.commerce.magento.graphql.ProductImage;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.sightly.SightlyWCMMode;
 import com.day.cq.wcm.api.Page;
@@ -216,12 +217,13 @@ public class ProductListImpl implements ProductList {
                 for (ProductInterface product : products.getItems()) {
                     try {
                         Price price = new PriceImpl(product.getPriceRange(), locale);
+                        ProductImage smallImage = product.getSmallImage();
                         listItems.add(new ProductListItemImpl(
                             product.getSku(),
                             product.getUrlKey(),
                             product.getName(),
                             price,
-                            product.getSmallImage().getUrl(),
+                            smallImage == null ? null : smallImage.getUrl(),
                             productPage,
                             null,
                             request));

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImplTest.java
@@ -39,6 +39,7 @@ import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableProduct;
 import com.adobe.cq.commerce.magento.graphql.ConfigurableVariant;
 import com.adobe.cq.commerce.magento.graphql.Money;
+import com.adobe.cq.commerce.magento.graphql.ProductImage;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.Query;
 import com.day.cq.wcm.api.Page;
@@ -134,7 +135,13 @@ public class ProductCarouselImplTest {
             priceFormatter.setCurrency(Currency.getInstance(amount.getCurrency().toString()));
             Assert.assertEquals(priceFormatter.format(amount.getValue()), item.getFormattedPrice());
 
-            Assert.assertEquals(productOrVariant.getThumbnail().getUrl(), item.getImageURL());
+            ProductImage thumbnail = productOrVariant.getThumbnail();
+            if (thumbnail == null) {
+                // if thumbnail is missing for a product in GraphQL response then thumbnail is null for the related item
+                Assert.assertNull(item.getImageURL());
+            } else {
+                Assert.assertEquals(thumbnail.getUrl(), item.getImageURL());
+            }
             idx++;
         }
     }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
@@ -40,6 +40,7 @@ import com.adobe.cq.commerce.core.components.testing.Utils;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.magento.graphql.CategoryInterface;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
+import com.adobe.cq.commerce.magento.graphql.ProductImage;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.Query;
 import com.adobe.cq.commerce.magento.graphql.StoreConfig;
@@ -170,7 +171,13 @@ public class ProductListImplTest {
             Assert.assertEquals(priceFormatter.format(productInterface.getPriceRange().getMinimumPrice().getFinalPrice().getValue()), item
                 .getFormattedPrice());
 
-            Assert.assertEquals(productInterface.getSmallImage().getUrl(), item.getImageURL());
+            ProductImage smallImage = productInterface.getSmallImage();
+            if (smallImage == null) {
+                // if small image is missing for a product in GraphQL response then image URL is null for the related item
+                Assert.assertNull(item.getImageURL());
+            } else {
+                Assert.assertEquals(smallImage.getUrl(), item.getImageURL());
+            }
         }
     }
 

--- a/bundles/core/src/test/resources/graphql/magento-graphql-category-result.json
+++ b/bundles/core/src/test/resources/graphql/magento-graphql-category-result.json
@@ -130,9 +130,6 @@
             "id": 1099,
             "sku": "eqrusugor",
             "name": "GoMobile Fitness Monitor/Smart Music Player",
-            "small_image": {
-              "url": "https://some-hostname.magentosite.cloud/media/catalog/product/g/o/gomobile_wrist_2.jpg"
-            },
             "url_key": "gomobile-fitness-monitor-smart-music-player",
             "price_range": {
               "minimum_price": {

--- a/bundles/core/src/test/resources/graphql/magento-graphql-productcarousel-result.json
+++ b/bundles/core/src/test/resources/graphql/magento-graphql-productcarousel-result.json
@@ -442,10 +442,6 @@
           "__typename": "ConfigurableProduct",
           "sku": "WJ01",
           "name": "Stellar Solar Jacket",
-          "thumbnail": {
-            "label": "Stellar Solar Jacket",
-            "url": "https://test-url.magentosite.cloud/media/wj01-red_main_6.jpg"
-          },
           "url_key": "stellar-solar-jacket",
           "price_range": {
             "minimum_price": {


### PR DESCRIPTION
 * fix NPE in product list when small image is missing for a product
 * fix NPE in product carousel when thumbnail is missing for a product

## Description

Product list component doesn't display a product if the product doesn't have a small_image (property is null) and it logs null pointer exception.
The same applied to the product carousel when a product doesn't have a thumbnail.

## Related Issue

CIF-1314


## How Has This Been Tested?

Unit test, manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
