### PR TITLE
CIF-1330 - GraphQL endpoint used by client-side code should be configurable

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
@@ -18,11 +18,11 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.models.annotations.Model;
 
 import com.adobe.cq.commerce.core.components.models.storeconfigexporter.StoreConfigExporter;
-import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
-import com.day.cq.commons.inherit.InheritanceValueMap;
 import com.day.cq.wcm.api.Page;
 
 @Model(
@@ -32,20 +32,23 @@ import com.day.cq.wcm.api.Page;
 public class StoreConfigExporterImpl implements StoreConfigExporter {
 
     protected static final String RESOURCE_TYPE = "core/cif/components/structure/page/v1/page";
+    private static final String CONFIG_NAME = "cloudconfigs/commerce";
     private static final String STORE_CODE_PROPERTY = "magentoStore";
+    private static final String GRAPHQL_ENDPOINT_PROPERTY = "magentoGraphqlEndpoint";
 
     @Inject
     private Page currentPage;
 
     private String storeView;
+    private String graphqlEndpoint = "/magento/graphql";
 
     @PostConstruct
     void initModel() {
-        InheritanceValueMap properties = new HierarchyNodeInheritanceValueMap(currentPage.getContentResource());
-        storeView = properties.getInherited(STORE_CODE_PROPERTY, String.class);
-        if (storeView == null) {
-            storeView = "default";
-        }
+        ConfigurationBuilder configurationBuilder = currentPage.adaptTo(ConfigurationBuilder.class);
+        ValueMap properties = configurationBuilder.name(CONFIG_NAME).asValueMap();
+
+        storeView = properties.get(STORE_CODE_PROPERTY, "default");
+        graphqlEndpoint = properties.get(GRAPHQL_ENDPOINT_PROPERTY, "/magento/graphql");
     }
 
     @Override
@@ -55,6 +58,6 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
 
     @Override
     public String getGraphqlEndpoint() {
-        return "/magento/graphql";
+        return graphqlEndpoint;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-package com.adobe.cq.commerce.core.components.internal.models.v1.storeviewexporter;
+package com.adobe.cq.commerce.core.components.internal.models.v1.storeconfigexporter;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -20,16 +20,16 @@ import javax.inject.Inject;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-import com.adobe.cq.commerce.core.components.models.storeviewexporter.StoreViewExporter;
+import com.adobe.cq.commerce.core.components.models.storeconfigexporter.StoreConfigExporter;
 import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
 import com.day.cq.commons.inherit.InheritanceValueMap;
 import com.day.cq.wcm.api.Page;
 
 @Model(
     adaptables = SlingHttpServletRequest.class,
-    adapters = { StoreViewExporter.class },
-    resourceType = StoreViewExporterImpl.RESOURCE_TYPE)
-public class StoreViewExporterImpl implements StoreViewExporter {
+    adapters = { StoreConfigExporter.class },
+    resourceType = StoreConfigExporterImpl.RESOURCE_TYPE)
+public class StoreConfigExporterImpl implements StoreConfigExporter {
 
     protected static final String RESOURCE_TYPE = "core/cif/components/structure/page/v1/page";
     private static final String STORE_CODE_PROPERTY = "magentoStore";
@@ -51,5 +51,10 @@ public class StoreViewExporterImpl implements StoreViewExporter {
     @Override
     public String getStoreView() {
         return storeView;
+    }
+
+    @Override
+    public String getGraphqlEndpoint() {
+        return "/magento/graphql";
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/StoreConfigExporter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/StoreConfigExporter.java
@@ -19,8 +19,14 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface StoreConfigExporter {
 
+    /**
+     * Returns the Magento store view identifier.
+     */
     String getStoreView();
 
+    /**
+     * Returns the GraphQL endpoint for client-side components.
+     */
     String getGraphqlEndpoint();
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/StoreConfigExporter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/StoreConfigExporter.java
@@ -12,13 +12,15 @@
  *
  ******************************************************************************/
 
-package com.adobe.cq.commerce.core.components.models.storeviewexporter;
+package com.adobe.cq.commerce.core.components.models.storeconfigexporter;
 
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
-public interface StoreViewExporter {
+public interface StoreConfigExporter {
 
     String getStoreView();
+
+    String getGraphqlEndpoint();
 
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-package com.adobe.cq.commerce.core.components.internal.models.v1.storeviewexporter;
+package com.adobe.cq.commerce.core.components.internal.models.v1.storeconfigexporter;
 
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.Assert;
@@ -23,7 +23,7 @@ import org.powermock.reflect.Whitebox;
 import io.wcm.testing.mock.aem.junit.AemContext;
 import io.wcm.testing.mock.aem.junit.AemContextCallback;
 
-public class StoreViewExporterTest {
+public class StoreConfigExporterTest {
 
     @Rule
     public final AemContext context = createContext("/context/jcr-content.json");
@@ -42,29 +42,29 @@ public class StoreViewExporterTest {
 
     @Test
     public void testStoreView() {
-        StoreViewExporterImpl storeViewExporter = new StoreViewExporterImpl();
-        Whitebox.setInternalState(storeViewExporter, "currentPage", context.currentPage(PAGE_A));
-        storeViewExporter.initModel();
+        StoreConfigExporterImpl storeConfigExporter = new StoreConfigExporterImpl();
+        Whitebox.setInternalState(storeConfigExporter, "currentPage", context.currentPage(PAGE_A));
+        storeConfigExporter.initModel();
 
-        Assert.assertEquals("my-store", storeViewExporter.getStoreView());
+        Assert.assertEquals("my-store", storeConfigExporter.getStoreView());
     }
 
     @Test
     public void testStoreViewInherited() {
-        StoreViewExporterImpl storeViewExporter = new StoreViewExporterImpl();
-        Whitebox.setInternalState(storeViewExporter, "currentPage", context.currentPage(PAGE_C));
-        storeViewExporter.initModel();
+        StoreConfigExporterImpl storeConfigExporter = new StoreConfigExporterImpl();
+        Whitebox.setInternalState(storeConfigExporter, "currentPage", context.currentPage(PAGE_C));
+        storeConfigExporter.initModel();
 
-        Assert.assertEquals("my-store", storeViewExporter.getStoreView());
+        Assert.assertEquals("my-store", storeConfigExporter.getStoreView());
     }
 
     @Test
     public void testStoreViewDefault() {
-        StoreViewExporterImpl storeViewExporter = new StoreViewExporterImpl();
-        Whitebox.setInternalState(storeViewExporter, "currentPage", context.currentPage(PAGE_D));
-        storeViewExporter.initModel();
+        StoreConfigExporterImpl storeConfigExporter = new StoreConfigExporterImpl();
+        Whitebox.setInternalState(storeConfigExporter, "currentPage", context.currentPage(PAGE_D));
+        storeConfigExporter.initModel();
 
-        Assert.assertEquals("default", storeViewExporter.getStoreView());
+        Assert.assertEquals("default", storeConfigExporter.getStoreView());
     }
 
 }

--- a/bundles/core/src/test/resources/context/jcr-content.json
+++ b/bundles/core/src/test/resources/context/jcr-content.json
@@ -2,6 +2,7 @@
   "pageA": {
     "jcr:primaryType": "cq:Page",
     "jcr:content": {
+      "sling:resourceType": "core/cif/components/structure/page/v1/page",
       "cq:cifProductPage": "/content/product-page",
       "cq:cifCategoryPage": "/content/category-page",
       "jcr:language": "en_US",

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -213,9 +213,8 @@ class CommerceGraphqlApi {
 
 (function() {
     function onDocumentReady() {
-        const endpoint = '/magento/graphql';
-        const storeView = document.querySelector('body').dataset.storeView;
-        window.CIF.CommerceGraphqlApi = new CommerceGraphqlApi({ endpoint, storeView });
+        const { storeView, graphqlEndpoint } = document.querySelector('body').dataset;
+        window.CIF.CommerceGraphqlApi = new CommerceGraphqlApi({ endpoint: graphqlEndpoint, storeView });
     }
 
     if (document.readyState !== 'loading') {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/page.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/page.html
@@ -14,14 +14,14 @@
 <!DOCTYPE html>
 <html
     data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page"
-    data-sly-use.storeView="com.adobe.cq.commerce.core.components.models.storeviewexporter.StoreViewExporter"
+    data-sly-use.storeView="com.adobe.cq.commerce.core.components.models.storeconfigexporter.StoreConfigExporter"
     lang="${page.language}"
     data-sly-use.head="head.html"
     data-sly-use.footer="footer.html"
     data-sly-use.redirect="redirect.html"
 >
     <head data-sly-call="${head.head @ page = page}"></head>
-    <body class="${page.cssClassNames}" data-store-view="${storeView.storeView}">
+    <body class="${page.cssClassNames}" data-store-view="${storeView.storeView}" data-graphql-endpoint="${storeView.graphqlEndpoint}">
         <sly
             data-sly-test.isRedirectPage="${page.redirectTarget && (wcmmode.edit || wcmmode.preview)}"
             data-sly-call="${redirect.redirect @ redirectTarget = page.redirectTarget}"

--- a/ui.apps/src/main/javascript/react-components/src/index.js
+++ b/ui.apps/src/main/javascript/react-components/src/index.js
@@ -19,10 +19,10 @@ import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
 
 const App = () => {
-    const storeView = document.querySelector('body').dataset.storeView;
+    const { storeView, graphqlEndpoint } = document.querySelector('body').dataset;
     return (
         <I18nextProvider i18n={i18n} defaultNS="common">
-            <CommerceApp uri={'/magento/graphql'} storeView={storeView}>
+            <CommerceApp uri={graphqlEndpoint} storeView={storeView}>
                 <Cart />
                 <AuthBar />
             </CommerceApp>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Added option to cloud configuration to set client-side Magento GraphQL endpoint
* Renamed `StoreViewExporter` to `StoreConfigExporter` and added Magento GraphQL endpoint as exported property.
* Updated React and JavaScript code to get GraphQL endpoint from the page model.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
