### PR TITLE
CIF-1343 - Absolute path for resource type in product teaser edit dialog

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
@@ -30,7 +30,7 @@
                                         <items jcr:primaryType="nt:unstructured">
                                             <product
                                                     jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="/libs/commerce/gui/components/common/cifproductfield"
+                                                    sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                     fieldDescription="The product or product variant displayed by the teaser"
                                                     fieldLabel="Select Product"
                                                     filter="folderOrProductOrVariant"


### PR DESCRIPTION
 * use relative path for resource type

<!--- Provide a general summary of your changes in the Title above -->

## Description

The product teaser edit dialog refers to cifproductfield with absolute path like:
sling:resourceType="/libs/commerce/gui/components/common/cifproductfield"

This breaks the cifproductfield in the edit dialog of the product teaser component on AEMaaCS.

## Related Issue

CIF-1343


## How Has This Been Tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
