### PR TITLE
CIF-1362: Pagination bar fixes

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/paginationbar.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v1/productlist/paginationbar.html
@@ -12,7 +12,7 @@
   ~ 
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.searchResultsSet="${@ searchResultsSet}">
-    <div class="category__pagination" data-sly-test.pager="${searchResultsSet.pager}">
+    <div class="category__pagination" data-sly-test.pager="${searchResultsSet.pager}" data-sly-test="${searchResultsSet.pager.pages.size > 1}">
         <div class="category__pagination_root">
             <sly data-sly-list.page="${pager.pages}">
                 <!--/*First Page button & Previous page button inactive */-->
@@ -41,14 +41,22 @@
                 </a>
 
                 <!--/*Page numbers iterated*/-->
-                <a class="category__pagination_tilebutton"
-                   href="${request.requestURI @ query=page.parameters}">
-                    <div class="category__pagination_tilebutton-text category__pagination_tilebutton-marker"
-                         data-sly-test.isCurrent="${page.pageNumber==pager.currentPage}">${page.pageNumber}</div>
-                    <div class="category__pagination_tilebutton-text" data-sly-test="${!isCurrent}">
-                        ${page.pageNumber}
-                    </div>
-                </a>
+                <sly data-sly-test="${page.pageNumber == pager.currentPage} ">
+                    <a class="category__pagination_tilebutton" >
+                        <div class="category__pagination_tilebutton-text category__pagination_tilebutton-marker">
+                            ${page.pageNumber}
+                        </div>
+                    </a>
+                </sly>
+
+                <sly data-sly-test="${page.pageNumber != pager.currentPage} ">
+                    <a class="category__pagination_tilebutton"
+                       href="${request.requestURI @ query=page.parameters}">
+                        <div class="category__pagination_tilebutton-text">
+                            ${page.pageNumber}
+                        </div>
+                    </a>
+                </sly>
 
                 <!--/* Ommitted pages: ... */-->
                 <a class=" category__pagination_tilebutton category__pagination_navbutton-inactive"


### PR DESCRIPTION
## Description

 * Hide pagination bar for one page results
 * Current page is not clickable anymore

## Related Issue

CIF-1362

## Motivation and Context

The current page can be clicked, this will just lead to reload of the current page and is useless > fix: current page should not be clickable
If there is only one result page, the pagination bar is visible > fix: hide pagination bar if only one result page

## How Has This Been Tested?

functional

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
