### PR TITLE
CIF-1484 - Panel title not updated when returning to sign-in

### DIFF
--- a/react-components/src/actions/navigation/actions.js
+++ b/react-components/src/actions/navigation/actions.js
@@ -92,9 +92,9 @@ export const showAccountCreated = ({ dispatch, t }) => {
 };
 
 export const showView = ({ dispatch, t, view }) => {
-    const title = stepTitles[view](t);
+    const title = stepTitles[view];
     if (title) {
-        dispatchEvent(new CustomEvent('aem.accmg.step', { detail: { title: title } }));
+        dispatchEvent(new CustomEvent('aem.accmg.step', { detail: { title: title(t) } }));
         dispatch({ type: 'changeView', view });
     }
 };

--- a/react-components/src/actions/navigation/actions.js
+++ b/react-components/src/actions/navigation/actions.js
@@ -90,3 +90,11 @@ export const showAccountCreated = ({ dispatch, t }) => {
     dispatchEvent(new CustomEvent('aem.accmg.step', { detail: { title: stepTitles[view](t) } }));
     dispatch({ type: 'changeView', view });
 };
+
+export const showView = ({ dispatch, t, view }) => {
+    const title = stepTitles[view](t);
+    if (title) {
+        dispatchEvent(new CustomEvent('aem.accmg.step', { detail: { title: title } }));
+        dispatch({ type: 'changeView', view });
+    }
+};

--- a/react-components/src/context/NavigationContext.js
+++ b/react-components/src/context/NavigationContext.js
@@ -69,6 +69,8 @@ const NavigationContextProvider = props => {
 
     const showAccountCreated = () => NavigationActions.showAccountCreated({ dispatch, t });
 
+    const showView = view => NavigationActions.showView({ dispatch, t, view });
+
     const handleBack = useCallback(() => {
         if (navigationState.view === null) {
             return;
@@ -84,7 +86,9 @@ const NavigationContextProvider = props => {
             showMyAccount();
             return;
         }
-        dispatch({ type: 'changeView', view: parent });
+        if (parent) {
+            showView(parent);
+        }
     }, [view]);
 
     useEventListener(document, 'aem.navigation.back', handleBack);


### PR DESCRIPTION
Make sure that navigation panel title is always updated when pressing the back arrow on the panel.

## Description

The navigation panel title is not updated after visiting the forgot password or create account panels and pressing the back arrow in the top of the navigation panel.

## Related Issue

CIF-1484

## How Has This Been Tested?

Manually.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
