### PR TITLE
CIF-1416 - Add CIF Core Components to AEM Components Library Page

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,9 +26,11 @@ _Note that the `ui.apps` examples content package depends on the same version of
 The mock GraphQL server can only serve content via HTTPS because our GraphQL client does not support non-secure connections for security reasons. This means you have to enable HTTPS on your AEM instance if you want to install and use the mock server. To do this, simply follow the [following documentation](https://docs.adobe.com/content/help/en/experience-manager-65/administering/security/ssl-by-default.html).
 If the self-signed certificate gets rejected by the browser, try adding it to the OS keychain and mark it as trusted.
 
-You must also enable anonymous access to the mock GraphQL server which will by defaut receive its requests on `https://localhost:8443/apps/cif-components-examples/graphql`. To do that, do the following:
+You must also enable anonymous access to the mock GraphQL server which will by defaut receive its requests on `/apps/cif-components-examples/graphql`. To do that, do the following:
 * In the AEM system configuration console, look for `Apache Sling Authentication Service`
 * Add the following line at the bottom of the "Authentication Requirements" property: `-/apps/cif-components-examples/graphql`
+
+The GraphQL client used by the examples is configured by default with the URL set to `$[env:CIF_MOCK_GRAPHQL_ENDPOINT]`, which means that it would use the environment variable `CIF_MOCK_GRAPHQL_ENDPOINT` (for local development, this is only supported by the Cloud SDK). For local development, if you do not want or cannot set that variable, just override that OSGi configuration manually and set it to `https://localhost:8443/apps/cif-components-examples/graphql`.
 
 ## How does it work?
 
@@ -38,7 +40,7 @@ The components are configured to use the CIF configuration defined at `/conf/cor
 
 All the CIF components used on the CIF library pages issue GraphQL requests to the mock GraphQL server which responds with mocked JSON responses that contain the data and links to images to be rendered by the component. We use a mock GraphQL server to avoid having any dependency on a pre-installed Magento instance with sample data.
 
-When everything is correctly installed, you should be able to open the library page at [http://localhost:4502/content/core-components-examples/library.html](http://localhost:4502/content/core-components-examples/library.html) and see the "Commerce" at the bottom of the left-side panel and at the bottom of the page content.
+When everything is correctly installed, you should be able to open the library page at [http://localhost:4502/content/core-components-examples/library.html](http://localhost:4502/content/core-components-examples/library.html) and see the "Commerce" section at the bottom of the left-side panel and at the bottom of the page content.
 
 ## Layout / design
 

--- a/examples/bundle/pom.xml
+++ b/examples/bundle/pom.xml
@@ -89,7 +89,8 @@
                         <Embed-Dependency>
                             graphql-java;inline=false;scope=compile|runtime,
                             java-dataloader;inline=false;scope=compile|runtime,
-                            reactive-streams;inline=false;scope=compile|runtime
+                            reactive-streams;inline=false;scope=compile|runtime,
+                            antlr4-runtime;inline=false;scope=compile|runtime
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
@@ -359,12 +360,18 @@
             <artifactId>graphql-java</artifactId>
             <version>14.0</version>
         </dependency>
+        
+        <!-- Transitive dependencies for graphql-java that must be embedded in the bundle -->
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>4.7.2</version>
+        </dependency>
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>java-dataloader</artifactId>
             <version>2.2.3</version>
         </dependency>
-
         <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>

--- a/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
+++ b/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
@@ -1,6 +1,6 @@
 productUrlTemplate="{{page}}.{{url_key}}.html#{{variant_sku}}"
 productIdentifierLocation="SELECTOR"
 productIdentifierType="URL_KEY"
-categoryUrlTemplate="{{page}}.{{id}}.html/{{url_path}}"
+categoryUrlTemplate="{{page}}.{{id}}.html"
 categoryIdentifierLocation="SELECTOR"
 categoryIdentifierType="ID"

--- a/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/config/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl-examples.config
+++ b/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/config/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl-examples.config
@@ -1,5 +1,5 @@
 identifier="examples"
-url="https://localhost:8443/apps/cif-components-examples/graphql"
+url="$[env:CIF_MOCK_GRAPHQL_ENDPOINT]"
 httpMethod="GET"
 acceptSelfSignedCertificates="true"
 maxHttpConnections="20"


### PR DESCRIPTION
- fix issues for deployment on AEM as a Cloud Service

## Description

This fixes some remaining issues when deploying the components to AEMaaCS:
- a transitive dependency for `graphql-java` is no longer exported in AEMaaCS
- the GraphQL endpoint must be configured with an environment variable

## How Has This Been Tested?

Tested on AEMaaCS with SNAPSHOT dependencies for the examples library.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
