### PR TITLE
CIF-1522 - Simplify the @adobe/aem-core-cif-react-components package

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-core-cif-react-components",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A collection of React components used in the AEM CIF Core Components project",
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
@@ -9,6 +9,10 @@
     "url": "https://github.com/adobe/aem-core-cif-components"
   },
   "module": "dist/index.js",
+  "files":[
+    "dist",
+    "i18n"
+  ],
   "scripts": {
     "lint": "eslint 'src/**/*.js'",
     "webpack:dev": "webpack --mode=development",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

* Increase the version to `1.2.0` in `package.json`
* Add the `files` setting so that only `dist` and `i18n` folders are part of the final package

## Related Issue

CIF-1522

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The `@adobe/aem-core-cif-react-components` npm package has way too many files in it.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Functional testing, run `npm pack --dry-run` and inspect the output

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
