### PR TITLE
CIF-1529 - Include CIF Add-On in IT setup for Cloud SDK

### DIFF
--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -29,17 +29,21 @@ try {
         // Connect to QP
         ci.sh('./qp.sh -v bind --server-hostname localhost --server-port 55555');
 
-        // The core components are already installed in the Cloud SDK
-        let extras = '';
+        // We install the graphql-client by default except with the CIF Add-On
+        let extras = '--bundle com.adobe.commerce.cif:graphql-client:1.6.1:jar';
         if (process.env.AEM == 'classic') {
-        	extras = '--bundle com.adobe.cq:core.wcm.components.all:2.9.0:zip';
+        	// The core components are already installed in the Cloud SDK
+        	extras += ' --bundle com.adobe.cq:core.wcm.components.all:2.9.0:zip';
+        } else if (process.env.AEM == 'addon') {
+        	// Download the CIF Add-On
+        	ci.sh(`curl -s "${process.env.CIF_ADDON_URL}" -o cif-addon.far`);
+        	extras = '--install-file cif-addon.far';
         }
         
         // Start CQ
         ci.sh(`./qp.sh -v start --id author --runmode author --port 4502 --qs-jar /home/circleci/cq/author/cq-quickstart.jar \
             --bundle org.apache.sling:org.apache.sling.junit.core:1.0.23:jar \
-            --bundle com.adobe.commerce.cif:graphql-client:1.6.1:jar \
-            --bundle com.adobe.commerce.cif:magento-graphql:6.0.0-magento235:jar ${extras} \
+            --bundle com.adobe.commerce.cif:magento-graphql:6.0.0-magento235:jar
             --bundle com.adobe.cq:core.wcm.components.examples.ui.apps:2.9.0:zip \
             --bundle com.adobe.cq:core.wcm.components.examples.ui.content:2.9.0:zip \
             ${ci.addQpFileDependency(config.modules['core-cif-components-apps'])} \
@@ -47,6 +51,7 @@ try {
             ${ci.addQpFileDependency(config.modules['core-cif-components-examples-bundle'])} \
             ${ci.addQpFileDependency(config.modules['core-cif-components-examples-apps'])} \
             ${ci.addQpFileDependency(config.modules['core-cif-components-examples-content'])} \
+            ${extras} \
             --vm-options \\\"-Xmx1536m -XX:MaxPermSize=256m -Djava.awt.headless=true -javaagent:${process.env.JACOCO_AGENT}=destfile=crx-quickstart/jacoco-it.exec\\\"`);
     });
 

--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -43,7 +43,7 @@ try {
         // Start CQ
         ci.sh(`./qp.sh -v start --id author --runmode author --port 4502 --qs-jar /home/circleci/cq/author/cq-quickstart.jar \
             --bundle org.apache.sling:org.apache.sling.junit.core:1.0.23:jar \
-            --bundle com.adobe.commerce.cif:magento-graphql:6.0.0-magento235:jar
+            --bundle com.adobe.commerce.cif:magento-graphql:6.0.0-magento235:jar \
             --bundle com.adobe.cq:core.wcm.components.examples.ui.apps:2.9.0:zip \
             --bundle com.adobe.cq:core.wcm.components.examples.ui.content:2.9.0:zip \
             ${extras} \

--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -46,12 +46,12 @@ try {
             --bundle com.adobe.commerce.cif:magento-graphql:6.0.0-magento235:jar
             --bundle com.adobe.cq:core.wcm.components.examples.ui.apps:2.9.0:zip \
             --bundle com.adobe.cq:core.wcm.components.examples.ui.content:2.9.0:zip \
+            ${extras} \
             ${ci.addQpFileDependency(config.modules['core-cif-components-apps'])} \
             ${ci.addQpFileDependency(config.modules['core-cif-components-core'])} \
             ${ci.addQpFileDependency(config.modules['core-cif-components-examples-bundle'])} \
             ${ci.addQpFileDependency(config.modules['core-cif-components-examples-apps'])} \
             ${ci.addQpFileDependency(config.modules['core-cif-components-examples-content'])} \
-            ${extras} \
             --vm-options \\\"-Xmx1536m -XX:MaxPermSize=256m -Djava.awt.headless=true -javaagent:${process.env.JACOCO_AGENT}=destfile=crx-quickstart/jacoco-it.exec\\\"`);
     });
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,19 @@ jobs:
     resource_class: large
     working_directory: /home/circleci/build
     <<: *integration_test_steps
- 
+    
+  integration-test-cloudready-with-addon:
+    docker:
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.4-jdk11
+        <<: *docker_auth
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem-cloudready:3919
+        <<: *docker_auth
+    environment:
+      AEM: addon
+    resource_class: large
+    working_directory: /home/circleci/build
+    <<: *integration_test_steps
+
   release:
     executor: cif_executor
     steps:
@@ -193,6 +205,14 @@ workflows:
             - karma
             - jest
       - integration-test-cloudready:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
+            - karma
+            - jest
+      - integration-test-cloudready-with-addon:
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
**Important**: the URL to download the CIF Add-On is set as a CircleCI variable `CIF_ADDON_URL`. This is obfuscated in the build output so nobody can have access to the add-on.

This has the main drawback that the version of the Add-On is also not visible, so we might forget to update it with each new release of the Add-On. Also because variables are also obfuscated in the CircleCI backend, it might become impossible with time to know which version we currently use.

We could hence maybe rename the variable to `CIF_ADDON_URL_2020_7_7_SNAPSHOT` so it would be straightforward from the name what version we use. If we release a new version of the Add-On, we would add for example the variable `CIF_ADDON_URL_2020_7_28` and update the build.

The drawback here is that we'd have to also update the variable in the `it-tests.js` file.

Feedback or other ideas is welcome.
