### PR TITLE
CIF-1547 - [React Components] Fix CSS reusability

### DIFF
--- a/react-components/webpack.config.js
+++ b/react-components/webpack.config.js
@@ -12,8 +12,9 @@
  *
  ******************************************************************************/
 const path = require('path');
-const {CleanWebpackPlugin} = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const pkg = require('./package.json');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const libraryName = pkg.name;
 
@@ -52,13 +53,12 @@ module.exports = {
             {
                 test: /\.css/,
                 use: [
-                    'style-loader',
+                    MiniCssExtractPlugin.loader,
                     {
                         loader: 'css-loader',
                         options: {
                             modules: {
-                                localIdentName:
-                                    '[name]__[local]__[hash:base64:5]'
+                                localIdentName: 'cmp-[folder]__[name]__[local]'
                             }
                         }
                     }
@@ -78,7 +78,13 @@ module.exports = {
             }
         ]
     },
-    plugins: [new CleanWebpackPlugin()],
+    plugins: [
+        new CleanWebpackPlugin(),
+        new MiniCssExtractPlugin({
+            filename: '[name].css',
+            chunkFilename: '[id].css'
+        })
+    ],
     devtool: 'source-map',
     mode: 'development',
     resolve: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The styles used by the client-side components could not be overwritten because they were embedded in the JS bundle. This causes the styles to be added to the page using a `<style>` tag, which means that it took precedence over any styling that was added using custom CSS in other client libraries.

To address this I did two things:
- drop the `style-loader` from the Webpack configuration and use `MiniCssExtractPlugin` to extract the CSS in a separate file.
- change the name of the generated CSS classes to scope them to the component, i.e. `.header__root` from the `minicart` becomes `.cmp-Minicart__header__root`.

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

CIF-1547

## Motivation and Context

Allow the styling of our client-side components

## How Has This Been Tested?

Functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
