### PR TITLE
CIF-1537 - split product teaser template into sub-templates

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/image.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/image.html
@@ -1,0 +1,20 @@
+<!--/*
+    Copyright 2020 Adobe Systems Incorporated
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/-->
+<template data-sly-template.actions="${@ product}">
+    <a class="item__images" href=${product.url}>
+        <img class="item__image" width="100%" height="100%" src="${product.image}" alt="${product.image}" />
+    </a>
+</template>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/productteaser.html
@@ -16,15 +16,15 @@
 
 <sly data-sly-use.product="com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser"
     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+    data-sly-use.imageTpl="image.html"
+    data-sly-use.titleTpl="title.html"
     data-sly-use.actionsTpl="actions.html"
     data-sly-test.isConfigured="${properties.selection}"
     data-sly-test.hasProduct="${product.url}" />
 
 <div data-sly-test="${isConfigured && hasProduct}" class="item__root" data-cmp-is="productteaser" data-virtual="${product.virtualProduct}">
-    <a class="item__images" href=${product.url}>
-        <img class="item__image" width="100%" height="100%" src="${product.image}" alt="${product.image}" />
-    </a>
-    <a class="item__name" href=${product.url}><span>${product.name}</span></a>
+    <sly data-sly-call="${imageTpl.actions @ product=product}" />
+    <sly data-sly-call="${titleTpl.actions @ product=product}" />
     <sly data-sly-use.template="core/cif/components/commons/v1/price.html"
         data-sly-call="${template.price @ priceRange=product.priceRange, displayYouSave=false}"/>
     <sly data-sly-call="${actionsTpl.actions @ product=product}"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/title.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/title.html
@@ -1,0 +1,18 @@
+<!--/*
+    Copyright 2020 Adobe Systems Incorporated
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/-->
+<template data-sly-template.actions="${@ product}">
+    <a class="item__name" href=${product.url}><span>${product.name}</span></a>
+</template>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For better extensibility split product teaser template into additional sub-templates. Projects can overlay only the sub-template the need to customize instead of the entire component template.

## Related Issue

CIF-1537

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
