### PR TITLE
Fix JSON.parse error when galleryRoot is not present in DOM

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/gallery.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/gallery.js
@@ -196,9 +196,8 @@ Gallery.events = {
 (function(document) {
     function onDocumentReady() {
         const galleryRoot = document.querySelector(Gallery.selectors.galleryRoot);
-        let galleryItemsJson = galleryRoot ? galleryRoot.dataset.galleryItems : { assets: [] };
 
-        const galleryItems = JSON.parse(galleryItemsJson);
+        const galleryItems = galleryRoot ? JSON.parse(galleryRoot.dataset.galleryItems) : { assets: [] };
         const gallery = new Gallery({ galleryItems });
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the galleryRoot element is not present in the DOM, the corresponding component attempts to use an empty object for constructing the list of gallery items. Unfortunately, this object is passed to `JSON.parse()` which does not accept objects and the code crashes with a `SyntaxError`.

<!--- Describe your changes in detail -->
Instead of parsing an object when the galleryRoot is unpresent, the code now simply avoids parsing completely and instead constructs an object to be used as fallback directly.

## Related Issue
https://github.com/adobe/aem-core-cif-components/issues/369
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
