### PR TITLE
trivial - Remove obsolete react-components clientlib

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/react-components/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/react-components/.content.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="cq:ClientLibraryFolder"
-    allowProxy="{Boolean}true"
-    categories="[core.cif.components.react]"
-    jsProcessor="[default:none,min:none]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/react-components/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/react-components/js.txt
@@ -1,2 +1,0 @@
-#base=dist
-index.js


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Remove obsolete `react-components` clientlib.
* The recommended approach is to use the React components as npm dependency in the `ui.frontend` package.

See https://github.com/adobe/aem-cif-guides-venia/pull/34.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
