### PR TITLE
CIF-1597 - Add Commerce Breadcrumb to CIF Components Library

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,14 +35,16 @@ To build and install that content package in a running AEM instance, simply use 
 
 ## Required configuration
 
-The mock GraphQL server can only serve content via HTTPS because our GraphQL client does not support non-secure connections for security reasons. This means you have to enable HTTPS on your AEM instance if you want to install and use the mock server. To do this, simply follow the [following documentation](https://docs.adobe.com/content/help/en/experience-manager-65/administering/security/ssl-by-default.html).
+Starting with version `1.6.1`, the GraphQL client does no longer enforce HTTPS: the support for HTTP can be enabled in the client OSGi configuration, but this should NOT be done on production systems!
+
+If you still want to use HTTPS, simply follow [this documentation](https://docs.adobe.com/content/help/en/experience-manager-65/administering/security/ssl-by-default.html) to enable HTTPS in your AEM instance.
 If the self-signed certificate gets rejected by the browser, try adding it to the OS keychain and mark it as trusted.
 
-You must also enable anonymous access to the mock GraphQL server which will by defaut receive its requests on `/apps/cif-components-examples/graphql`. To do that, do the following:
+On an author instance you must also enable anonymous access to the mock GraphQL server which will by defaut receive its requests on `/apps/cif-components-examples/graphql`. To do that, do the following:
 * In the AEM system configuration console, look for `Apache Sling Authentication Service`
 * Add the following line at the bottom of the "Authentication Requirements" property: `-/apps/cif-components-examples/graphql`
 
-The GraphQL client used by the examples is configured by default with the URL set to `$[env:CIF_MOCK_GRAPHQL_ENDPOINT]`, which means that it would use the environment variable `CIF_MOCK_GRAPHQL_ENDPOINT` (for local development, this is only supported by the Cloud SDK). For local development, if you do not want or cannot set that variable, just override that OSGi configuration manually and set it to `https://localhost:8443/apps/cif-components-examples/graphql`.
+The GraphQL client used by the examples is configured by default with the URL set to `$[env:CIF_MOCK_GRAPHQL_ENDPOINT]`, which means that it would use the environment variable `CIF_MOCK_GRAPHQL_ENDPOINT` (for local development, this is only supported by the Cloud SDK). For local development, if you do not want or cannot set that variable, just override that OSGi configuration manually and set it to `https://localhost:8443/apps/cif-components-examples/graphql` for HTTPS or `http://localhost:4502/apps/cif-components-examples/graphql` for HTTP on an author instance with default port 4502.
 
 ## How does it work?
 

--- a/examples/bundle/src/main/java/com/adobe/cq/commerce/core/examples/servlets/GraphqlServlet.java
+++ b/examples/bundle/src/main/java/com/adobe/cq/commerce/core/examples/servlets/GraphqlServlet.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -107,6 +108,8 @@ public class GraphqlServlet extends SlingAllMethodsServlet {
     private static final String CATEGORY_TREE_JSON = "magento-graphql-categories.json";
     private static final String CATEGORY_JSON = "magento-graphql-category.json";
     private static final String FEATURED_CATEGORY_LIST_JSON = "magento-graphql-featuredcategorylist.json";
+    private static final String PRODUCTS_BREADCRUMB_JSON = "magento-graphql-products-breadcrumb.json";
+    private static final String CATEGORYLIST_BREADCRUMB_JSON = "magento-graphql-categorylist-breadcrumb.json";
 
     private Gson gson;
     private GraphQL graphQL;
@@ -314,6 +317,9 @@ public class GraphqlServlet extends SlingAllMethodsServlet {
                     case "category": {
                         return readCategoryResponse(env);
                     }
+                    case "categoryList": {
+                        return readCategoryListResponse(env);
+                    }
                     case "customAttributeMetadata": {
                         GraphqlResponse<Query, Error> graphqlResponse = readGraphqlResponse(ATTRIBUTES_JSON);
                         return graphqlResponse.getData().getCustomAttributeMetadata();
@@ -329,6 +335,7 @@ public class GraphqlServlet extends SlingAllMethodsServlet {
             .type("Query", builder -> builder.dataFetcher("products", staticDataFetcher))
             .type("Query", builder -> builder.dataFetcher("storeConfig", staticDataFetcher))
             .type("Query", builder -> builder.dataFetcher("category", staticDataFetcher))
+            .type("Query", builder -> builder.dataFetcher("categoryList", staticDataFetcher))
             .type("Query", builder -> builder.dataFetcher("customAttributeMetadata", staticDataFetcher))
             .build();
     }
@@ -351,6 +358,8 @@ public class GraphqlServlet extends SlingAllMethodsServlet {
             return readProductsFrom(UPSELL_PRODUCTS_JSON);
         } else if (selectionSet.contains("items/crosssell_products")) {
             return readProductsFrom(CROSSSELL_PRODUCTS_JSON);
+        } else if (selectionSet.contains("items/categories/breadcrumbs")) {
+            return readProductsFrom(PRODUCTS_BREADCRUMB_JSON);
         }
 
         Map<String, Object> args = env.getArguments();
@@ -429,5 +438,20 @@ public class GraphqlServlet extends SlingAllMethodsServlet {
 
         GraphqlResponse<Query, Error> graphqlResponse = readGraphqlResponse(filename);
         return graphqlResponse.getData().getCategory();
+    }
+
+    /**
+     * Based on the GraphQL query, this method returns a list of Magento <code>CategoryTree</code> objects
+     * that "matches" the data expected by each CIF component. Each CIF component indeed expects a
+     * specific JSON response. Luckily, each GraphQL query sent by each component is different so
+     * we can "detect" what response should be returned.
+     * 
+     * @param env The metadata of the GraphQL query.
+     * @return A list of Magento <code>CategoryTree</code> objects.
+     */
+    private List<CategoryTree> readCategoryListResponse(DataFetchingEnvironment env) {
+        // For now, only the breadcrumb component queries 'CategoryList'
+        GraphqlResponse<Query, Error> graphqlResponse = readGraphqlResponse(CATEGORYLIST_BREADCRUMB_JSON);
+        return graphqlResponse.getData().getCategoryList();
     }
 }

--- a/examples/bundle/src/main/resources/graphql/magento-graphql-categorylist-breadcrumb.json
+++ b/examples/bundle/src/main/resources/graphql/magento-graphql-categorylist-breadcrumb.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "categoryList": [
+      {
+        "id": 1,
+        "url_path": "outdoor/collection",
+        "name": "Collection",
+        "breadcrumbs": [
+          {
+            "category_id": 2,
+            "category_url_path": "outdoor",
+            "category_name": "Outdoor"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/bundle/src/main/resources/graphql/magento-graphql-products-breadcrumb.json
+++ b/examples/bundle/src/main/resources/graphql/magento-graphql-products-breadcrumb.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "products": {
+      "items": [
+        {
+          "__typename": "ConfigurableProduct",
+          "sku": "MH01",
+          "url_key": "chaz-kangeroo-hoodie",
+          "name": "Chaz Kangeroo Hoodie",
+          "categories": [
+            {
+              "__typename": "CategoryTree",
+              "id": 1,
+              "url_path": "outdoor/collection",
+              "name": "Collection",
+              "breadcrumbs": [
+                {
+                  "category_id": 2,
+                  "category_url_path": "outdoor",
+                  "category_name": "Outdoor"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/examples/bundle/src/test/java/com/adobe/cq/commerce/core/examples/servlets/GraphqlServletTest.java
+++ b/examples/bundle/src/test/java/com/adobe/cq/commerce/core/examples/servlets/GraphqlServletTest.java
@@ -71,6 +71,7 @@ import com.adobe.cq.commerce.magento.graphql.QueryQuery;
 import com.adobe.cq.commerce.magento.graphql.gson.Error;
 import com.adobe.cq.commerce.magento.graphql.gson.QueryDeserializer;
 import com.adobe.cq.sightly.SightlyWCMMode;
+import com.adobe.cq.wcm.core.components.models.Breadcrumb;
 import com.day.cq.wcm.api.LanguageManager;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
@@ -115,6 +116,9 @@ public class GraphqlServletTest {
     }
 
     private static final String PAGE = "/content/page";
+    private static final String PRODUCT_PAGE = "/content/page/catalogpage/product-page";
+    private static final String CATEGORY_PAGE = "/content/page/catalogpage/category-page";
+
     private static final String PRODUCT_RESOURCE = PAGE + "/jcr:content/root/responsivegrid/product";
     private static final String PRODUCT_LIST_RESOURCE = PAGE + "/jcr:content/root/responsivegrid/productlist";
     private static final String PRODUCT_CAROUSEL_RESOURCE = PAGE + "/jcr:content/root/responsivegrid/productcarousel";
@@ -125,6 +129,8 @@ public class GraphqlServletTest {
     private static final String SEARCH_RESULTS_RESOURCE = PAGE + "/jcr:content/root/responsivegrid/searchresults";
     private static final String FEATURED_CATEGORY_LIST_RESOURCE = PAGE + "/jcr:content/root/responsivegrid/featuredcategorylist";
     private static final String NAVIGATION_RESOURCE = PAGE + "/jcr:content/root/responsivegrid/navigation";
+    private static final String PRODUCTPAGE_BREADCRUMB_RESOURCE = PRODUCT_PAGE + "/jcr:content/breadcrumb";
+    private static final String CATEGORYPAGE_BREADCRUMB_RESOURCE = CATEGORY_PAGE + "/jcr:content/breadcrumb";
 
     private static final String CIF_DAM_ROOT = "/content/dam/core-components-examples/library/cif-sample-assets/";
 
@@ -181,7 +187,11 @@ public class GraphqlServletTest {
     }
 
     private Resource prepareModel(String resourcePath) throws ServletException {
-        Page page = Mockito.spy(context.currentPage(PAGE));
+        return prepareModel(resourcePath, PAGE);
+    }
+
+    private Resource prepareModel(String resourcePath, String currentPage) throws ServletException {
+        Page page = Mockito.spy(context.currentPage(currentPage));
         context.currentPage(page);
         context.currentResource(resourcePath);
         Resource resource = Mockito.spy(context.currentResource());
@@ -372,6 +382,28 @@ public class GraphqlServletTest {
 
         Navigation navigationModel = context.request().adaptTo(Navigation.class);
         Assert.assertEquals(7, navigationModel.getItems().size()); // Our test catalog has 7 top-level categories
+    }
+
+    @Test
+    public void testProductPageBreadcrumbModel() throws ServletException {
+        prepareModel(PRODUCTPAGE_BREADCRUMB_RESOURCE, PRODUCT_PAGE);
+
+        MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) context.request().getRequestPathInfo();
+        requestPathInfo.setSelectorString("beaumont-summit-kit");
+
+        Breadcrumb breadcrumbModel = context.request().adaptTo(Breadcrumb.class);
+        Assert.assertEquals(4, breadcrumbModel.getItems().size()); // The base page, 2 categories and the product
+    }
+
+    @Test
+    public void testCategoryPageBreadcrumbModel() throws ServletException {
+        prepareModel(PRODUCTPAGE_BREADCRUMB_RESOURCE, CATEGORY_PAGE);
+
+        MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) context.request().getRequestPathInfo();
+        requestPathInfo.setSelectorString("1");
+
+        Breadcrumb breadcrumbModel = context.request().adaptTo(Breadcrumb.class);
+        Assert.assertEquals(3, breadcrumbModel.getItems().size()); // The base page and 2 categories
     }
 
     @Test

--- a/examples/bundle/src/test/java/com/adobe/cq/commerce/core/examples/servlets/ResourceTypeImplementationPicker.java
+++ b/examples/bundle/src/test/java/com/adobe/cq/commerce/core/examples/servlets/ResourceTypeImplementationPicker.java
@@ -41,6 +41,18 @@ public class ResourceTypeImplementationPicker implements ImplementationPicker {
             return implementationsTypes[0];
         }
 
+        // This is a special case only for the breadcrumb component to support @Via with ForcedResourceType
+        if (!(adaptable instanceof MockSlingHttpServletRequest)) {
+            for (int i = 0, l = implementationsTypes.length; i < l; i++) {
+                Class<?> implementationsType = implementationsTypes[i];
+                LOGGER.debug("... with " + implementationsType.getCanonicalName());
+                if (implementationsType.getCanonicalName().contains("wcm")) {
+                    LOGGER.debug("--> Returning " + implementationsType.getCanonicalName());
+                    return implementationsType;
+                }
+            }
+        }
+
         MockSlingHttpServletRequest request = (MockSlingHttpServletRequest) adaptable;
         String componentName = StringUtils.substringAfterLast(request.getResource().getResourceType(), "/");
 

--- a/examples/bundle/src/test/resources/context/jcr-content.json
+++ b/examples/bundle/src/test/resources/context/jcr-content.json
@@ -2,8 +2,8 @@
   "page": {
     "jcr:primaryType": "cq:Page",
     "jcr:content": {
-      "cq:cifProductPage": "/content/product-page",
-      "cq:cifCategoryPage": "/content/category-page",
+      "cq:cifProductPage": "/content/page/catalogpage/product-page",
+      "cq:cifCategoryPage": "/content/page/catalogpage/category-page",
       "jcr:language": "en_US",
       "jcr:primaryType": "cq:PageContent",
       "root": {
@@ -70,19 +70,31 @@
         "magentoRootCategoryId": "2",
         "showMainCategories": true,
         "sling:resourceType": "core/cif/components/structure/catalogpage/v1/catalogpage"
+      },
+      "product-page": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+          "jcr:language": "en_US",
+          "breadcrumb": {
+            "sling:resourceType": "core/cif/components/structure/breadcrumb/v1/breadcrumb",
+            "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
+            "startLevel": "1",
+            "structureDepth": "2"
+          }
+        }
+      },
+      "category-page": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+          "jcr:language": "en_US",
+          "breadcrumb": {
+            "sling:resourceType": "core/cif/components/structure/breadcrumb/v1/breadcrumb",
+            "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
+            "startLevel": "1",
+            "structureDepth": "2"
+          }
+        }
       }
-    }
-  },
-  "product-page": {
-    "jcr:primaryType": "cq:Page",
-    "jcr:content": {
-      "jcr:language": "en_US"
-    }
-  },
-  "category-page": {
-    "jcr:primaryType": "cq:Page",
-    "jcr:content": {
-      "jcr:language": "en_US"
     }
   }
 }

--- a/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/components/breadcrumb/.content.xml
+++ b/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/components/breadcrumb/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="The breadcrumb component for the CIF Components Library"
+    jcr:primaryType="cq:Component"
+    jcr:title="Commerce Breadcrumb"
+    sling:resourceSuperType="core/cif/components/structure/breadcrumb/v1/breadcrumb"
+    componentGroup="Core Components Examples"/>

--- a/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/.content.xml
+++ b/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/.content.xml
@@ -222,6 +222,29 @@
                                 width="12"/>
                         </cq:responsive>
                     </teaser_1837085987>
+                    <teaser_1837085997
+                        cq:styleIds="[1547060090076]"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Breadcrumb"
+                        sling:resourceType="core-components-examples/components/teaser"
+                        actionsEnabled="false"
+                        descriptionFromPage="true"
+                        fileReference="/content/dam/core-components-examples/library/components/breadcrumb.svg"
+                        linkURL="/content/core-components-examples/library/commerce/breadcrumb"
+                        textIsRich="true"
+                        titleFromPage="false">
+                        <cq:responsive jcr:primaryType="nt:unstructured">
+                            <default
+                                jcr:primaryType="nt:unstructured"
+                                width="3"/>
+                            <small
+                                jcr:primaryType="nt:unstructured"
+                                width="4"/>
+                            <extrasmall
+                                jcr:primaryType="nt:unstructured"
+                                width="12"/>
+                        </cq:responsive>
+                    </teaser_1837085997>
                 </container_1589240807>
             </responsivegrid>
         </root>

--- a/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/commerce/.content.xml
+++ b/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/commerce/.content.xml
@@ -26,4 +26,5 @@
     <featuredcategorylist/>
     <teaser/>
     <navigation/>
+    <breadcrumb/>
 </jcr:root>

--- a/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/commerce/breadcrumb/.content.xml
+++ b/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/commerce/breadcrumb/.content.xml
@@ -2,13 +2,13 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:lastModified="{Date}2020-07-15T13:25:39.732+02:00"
+        cq:lastModified="{Date}2020-08-24T14:03:02.160+02:00"
         cq:lastModifiedBy="admin"
         cq:tags="[]"
         cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
-        jcr:description="Display commerce product data"
+        jcr:description="Display the site and commerce breadcrumb"
         jcr:primaryType="cq:PageContent"
-        jcr:title="Product"
+        jcr:title="Breadcrumb"
         sling:resourceType="cif-components-examples/components/page">
         <root
             jcr:primaryType="nt:unstructured"
@@ -20,21 +20,21 @@
                     cq:styleIds="[1644862132301]"
                     jcr:created="{Date}2019-02-15T19:05:53.032+01:00"
                     jcr:createdBy="admin"
-                    jcr:lastModified="{Date}2019-02-15T19:09:39.787+01:00"
+                    jcr:lastModified="{Date}2020-06-03T15:11:11.696+02:00"
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;h1>Product&lt;sub>v1&lt;/sub>&lt;/h1>"
+                    text="&lt;h1>Commerce Breadcrumb&lt;sub>v1&lt;/sub>&lt;/h1>"
                     textIsRich="true"/>
                 <text
                     cq:styleIds="[1544762734201]"
                     jcr:created="{Date}2018-12-06T19:11:23.947+01:00"
                     jcr:createdBy="admin"
-                    jcr:lastModified="{Date}2020-07-15T13:25:39.729+02:00"
+                    jcr:lastModified="{Date}2020-08-24T13:55:29.574+02:00"
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>The product component is a server side component written in HTL, allowing to display product details. The product details are retrieved from Magento via GraphQL using the product identifier provided in the URL selector.&lt;/p>&#xd;&#xa;&lt;p>On an author instance, when the page URL does not contain any selector, like for example when the page is edited in the AEM Sites editor, the component displays some placeholder data. On a publish instance, not setting any selector displays a &amp;quot;Product not found&amp;quot; message.&lt;br>&#xd;&#xa;&lt;/p>&#xd;&#xa;&lt;p>Note that when a selector is set, this example page always displays the same product data based on some sample data. Try different options:&lt;/p>&#xd;&#xa;&lt;ul>&#xd;&#xa;&lt;li>&lt;a href=&quot;/content/core-components-examples/library/commerce/product.chaz-kangeroo-hoodie.html&quot;>Showing sample data (selector is set in URL)&lt;/a>&lt;/li>&#xd;&#xa;&lt;li>&lt;a href=&quot;/content/core-components-examples/library/commerce/product.set-of-sprite-yoga-straps.html&quot;>Showing sample data for a grouped product (only for this particular selector in the URL)&lt;/a>&lt;/li>&#xd;&#xa;&lt;li>&lt;a href=&quot;/content/core-components-examples/library/commerce/product.html&quot;>Showing placeholder data on author instance (no selector in URL)&lt;/a>&lt;/li>&#xd;&#xa;&lt;/ul>&#xd;&#xa;&lt;div>For the two examples with sample data, the clientlib part of the component will also issue a client-side GraphQL query to refetch the product prices on page load. This demonstrates how prices can be refreshed upon page load even if the rest of the page data may be cached in the AEM dispatcher.&lt;br>&#xd;&#xa;&lt;/div>&#xd;&#xa;"
+                    text="&lt;p style=&quot;margin-top: 0.0px; margin-bottom: 16.0px; color: rgb(36,41,46); font-size: 16.0px; font-style: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0.0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0.0px;&quot;>The Commerce Breadcrumb component is a server-side component written in HTL, rendering a combined AEM page and commerce catalog breadcrumb. The commerce elements of the breadcrumb (i.e. categories and product) are retrieved from Magento via GraphQL. The main usage of this component would be as part of all page templates which include a breadcrumb.&lt;/p>&#xd;&#xa;&lt;p style=&quot;margin-top: 0.0px; margin-bottom: 16.0px; color: rgb(36,41,46); font-size: 16.0px; font-style: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0.0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0.0px;&quot;>This component is based on the &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/tree/master/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb&quot;>Breadcrumb component&lt;/a>&lt;span> &lt;/span>of the AEM Core Components library.&lt;/p>&#xd;&#xa;"
                     textIsRich="true"/>
                 <teaser
                     cq:styleIds="[1550165685463]"
@@ -49,7 +49,7 @@
                     actionsEnabled="false"
                     descriptionFromPage="false"
                     fileReference="/content/dam/core-components-examples/library/github-logo.svg"
-                    linkURL="https://github.com/adobe/aem-core-cif-components/tree/master/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product"
+                    linkURL="https://github.com/adobe/aem-core-cif-components/tree/master/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/breadcrumb/v1/breadcrumb"
                     textIsRich="true"
                     titleFromPage="false"/>
                 <title_865328580
@@ -75,11 +75,11 @@
                 <text_1337506761
                     jcr:created="{Date}2018-12-06T19:23:41.968+01:00"
                     jcr:createdBy="admin"
-                    jcr:lastModified="{Date}2019-05-22T11:26:32.604+03:00"
+                    jcr:lastModified="{Date}2020-08-24T14:03:02.155+02:00"
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>The component, simply displaying placeholder data.&lt;/p>"
+                    text="&lt;p>The component is configured to display all the AEM pages under the &amp;quot;root&amp;quot; of the library. In addition to displaying content pages, the component will display commerce data when used on a product or category page. Check the examples at the bottom of the following pages:&lt;/p>&#xd;&#xa;&lt;ul>&#xd;&#xa;&lt;li>&lt;a href=&quot;/content/core-components-examples/library/commerce/product.chaz-kangeroo-hoodie.html&quot;>Product page with sample data.&lt;/a>&lt;/li>&#xd;&#xa;&lt;li>&lt;a href=&quot;/content/core-components-examples/library/commerce/productlist.1.html&quot;>Category page with sample data.&lt;/a>&lt;br>&#xd;&#xa;&lt;/li>&#xd;&#xa;&lt;/ul>&#xd;&#xa;"
                     textIsRich="true"/>
                 <demo
                     jcr:created="{Date}2018-12-07T12:55:03.496+01:00"
@@ -91,54 +91,7 @@
                     <component
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="core-components-examples/components/demo/component">
-                        <product
-                            jcr:created="{Date}2019-03-06T14:11:01.819+01:00"
-                            jcr:createdBy="admin"
-                            jcr:lastModified="{Date}2019-05-21T18:59:35.605+03:00"
-                            jcr:lastModifiedBy="admin"
-                            jcr:primaryType="nt:unstructured"
-                            sling:resourceType="cif-components-examples/components/product"
-                            loadClientPrice="{Boolean}true"/>
-                    </component>
-                    <info
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core-components-examples/components/tabs">
-                        <properties
-                            cq:panelTitle="Properties"
-                            jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core-components-examples/components/demo/properties"
-                            reference="../../component"/>
-                        <markup
-                            cq:panelTitle="Markup"
-                            jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core-components-examples/components/demo/markup"
-                            reference="../../component"/>
-                    </info>
-                </demo>
-                <text_1337506762
-                    jcr:created="{Date}2018-12-06T19:23:41.968+01:00"
-                    jcr:createdBy="admin"
-                    jcr:lastModified="{Date}2019-05-22T11:26:32.604+03:00"
-                    jcr:lastModifiedBy="admin"
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>In addition to the product component, this demonstrates the breadcrumb component displaying page content and commerce data up to the product page.&lt;/p>"
-                    textIsRich="true"/>
-                <breadcrumb-demo
-                    jcr:created="{Date}2018-12-07T12:55:03.496+01:00"
-                    jcr:createdBy="admin"
-                    jcr:lastModified="{Date}2018-12-07T12:55:03.496+01:00"
-                    jcr:lastModifiedBy="admin"
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="cif-components-examples/components/demo">
-                    <component
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core-components-examples/components/demo/component">
                         <breadcrumb
-                            jcr:created="{Date}2020-08-17T16:22:56.378+02:00"
-                            jcr:createdBy="admin"
-                            jcr:lastModified="{Date}2020-08-17T16:22:56.378+02:00"
-                            jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="cif-components-examples/components/breadcrumb"
                             startLevel="2"
@@ -158,7 +111,7 @@
                             sling:resourceType="core-components-examples/components/demo/markup"
                             reference="../../component"/>
                     </info>
-                </breadcrumb-demo>
+                </demo>
             </responsivegrid>
         </root>
     </jcr:content>

--- a/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/commerce/productlist/.content.xml
+++ b/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/commerce/productlist/.content.xml
@@ -118,6 +118,50 @@
                             reference="../../component"/>
                     </info>
                 </demo>
+                <text_1337506762
+                    jcr:created="{Date}2018-12-06T19:23:41.968+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2019-05-22T11:26:32.604+03:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core/wcm/components/text/v2/text"
+                    text="&lt;p>In addition to the productlist component, this demonstrates the breadcrumb component displaying page content and commerce data up to the category page.&lt;/p>"
+                    textIsRich="true"/>
+                <breadcrumb-demo
+                    jcr:created="{Date}2018-12-07T12:55:03.496+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2018-12-07T12:55:03.496+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="cif-components-examples/components/demo">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <breadcrumb
+                            jcr:created="{Date}2020-08-17T16:22:56.378+02:00"
+                            jcr:createdBy="admin"
+                            jcr:lastModified="{Date}2020-08-17T16:22:56.378+02:00"
+                            jcr:lastModifiedBy="admin"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="cif-components-examples/components/breadcrumb"
+                            startLevel="2"
+                            structureDepth="2"/>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                    </info>
+                </breadcrumb-demo>
             </responsivegrid>
         </root>
     </jcr:content>

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/BreadcrumbComponentIT.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/BreadcrumbComponentIT.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ *    Copyright 2020 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.it.http;
+
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BreadcrumbComponentIT extends CommerceTestBase {
+
+    // Differentiates between the HTML output of the component itself, and the tab displaying the HTML output
+    private static final String BREADCRUMB_SELECTOR = CMP_EXAMPLES_DEMO_SELECTOR + " .breadcrumb ";
+    protected static final String BREADCRUMB_ITEM_SELECTOR = BREADCRUMB_SELECTOR + ".cmp-breadcrumb__item";
+
+    @Test
+    public void testProductBreadcrumbWithPlaceholderData() throws ClientException {
+        SlingHttpResponse response = adminAuthor.doGet(COMMERCE_LIBRARY_PATH + "/breadcrumb.html", 200);
+        Document doc = Jsoup.parse(response.getContent());
+
+        // Component Library > Commerce > Breadcrumb
+        Elements elements = doc.select(BreadcrumbComponentIT.BREADCRUMB_ITEM_SELECTOR);
+        Assert.assertEquals(3, elements.size());
+    }
+}

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/NavigationComponentIT.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/NavigationComponentIT.java
@@ -34,6 +34,6 @@ public class NavigationComponentIT extends CommerceTestBase {
 
         // Check the number of elements in the navigation menu
         Elements elements = doc.select(NAVIGATION_SELECTOR + ".categoryTree__root > .categoryTree__tree > .cmp-navigation__item");
-        Assert.assertEquals(9, elements.size());
+        Assert.assertEquals(10, elements.size());
     }
 }

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/ProductComponentIT.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/ProductComponentIT.java
@@ -62,4 +62,24 @@ public class ProductComponentIT extends CommerceTestBase {
         Elements elements = doc.select(PRODUCT_SELECTOR + ".productFullDetail__productName > span");
         Assert.assertEquals("Product name", elements.first().html());
     }
+
+    @Test
+    public void testProductBreadcrumbWithSampleData() throws ClientException {
+        SlingHttpResponse response = adminAuthor.doGet(COMMERCE_LIBRARY_PATH + "/product.chaz-kangeroo-hoodie.html", 200);
+        Document doc = Jsoup.parse(response.getContent());
+
+        // Component Library > Commerce > Outdoor > Collection > Chaz Kangeroo Hoodie
+        Elements elements = doc.select(BreadcrumbComponentIT.BREADCRUMB_ITEM_SELECTOR);
+        Assert.assertEquals(5, elements.size());
+    }
+
+    @Test
+    public void testProductBreadcrumbWithPlaceholderData() throws ClientException {
+        SlingHttpResponse response = adminAuthor.doGet(COMMERCE_LIBRARY_PATH + "/product.html", 200);
+        Document doc = Jsoup.parse(response.getContent());
+
+        // Component Library > Commerce
+        Elements elements = doc.select(BreadcrumbComponentIT.BREADCRUMB_ITEM_SELECTOR);
+        Assert.assertEquals(2, elements.size());
+    }
 }

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/ProductListComponentIT.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/ProductListComponentIT.java
@@ -62,4 +62,24 @@ public class ProductListComponentIT extends CommerceTestBase {
         elements = doc.select(PRODUCTLIST_SELECTOR + ".gallery__items > .item__root");
         Assert.assertEquals(6, elements.size());
     }
+
+    @Test
+    public void testProductListBreadcrumbWithSampleData() throws ClientException {
+        SlingHttpResponse response = adminAuthor.doGet(COMMERCE_LIBRARY_PATH + "/productlist.1.html", 200);
+        Document doc = Jsoup.parse(response.getContent());
+
+        // Component Library > Commerce > Outdoor > Collection
+        Elements elements = doc.select(BreadcrumbComponentIT.BREADCRUMB_ITEM_SELECTOR);
+        Assert.assertEquals(4, elements.size());
+    }
+
+    @Test
+    public void testProductListBreadcrumbWithPlaceholderData() throws ClientException {
+        SlingHttpResponse response = adminAuthor.doGet(COMMERCE_LIBRARY_PATH + "/productlist.html", 200);
+        Document doc = Jsoup.parse(response.getContent());
+
+        // Component Library > Commerce
+        Elements elements = doc.select(BreadcrumbComponentIT.BREADCRUMB_ITEM_SELECTOR);
+        Assert.assertEquals(2, elements.size());
+    }
 }


### PR DESCRIPTION
Adds a page for the Breadcrumb component in the components library. We also add an example of the breadcrumb on the product and productlist pages, because this is where it's most interesting. Note that these two examples are added in separate "demo" boxes because the demo component does not support rendering multiple components.

## How Has This Been Tested?

Extended integration tests.

## Screenshots (if appropriate):

![Screenshot 2020-08-25 at 14 43 05](https://user-images.githubusercontent.com/24548615/91175790-9d575d80-e6e1-11ea-8e96-7a99f58e6f8b.png)

This shows the extra example on the product page:

![Screenshot 2020-08-25 at 14 44 31](https://user-images.githubusercontent.com/24548615/91175801-a0eae480-e6e1-11ea-9870-53db3152d604.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
