### PR TITLE
CIF-1610 - Cookies are not correctly set when hostname has a port

### DIFF
--- a/react-components/src/utils/hooks.js
+++ b/react-components/src/utils/hooks.js
@@ -35,7 +35,7 @@ export const useCookieValue = cookieName => {
     }
     let value = checkCookie(cookieName) ? cookieValue(cookieName) : '';
     const setCookieValue = (value, age) => {
-        const cookieSettings = `path=/; domain=${window.location.host};Max-Age=${age !== undefined ? age : 3600}`;
+        const cookieSettings = `path=/; domain=${window.location.hostname};Max-Age=${age !== undefined ? age : 3600}`;
         document.cookie = `${cookieName}=${value};${cookieSettings}`;
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Whenever the React components were served from a host that includes a port, the cookies (for cart, login) could not be set, because the cookie string was invalid and was rejected by the browser.
* The variable `window.location.host` which was used to set the cookie domain includes the port if used. This is invalid according to the cookie spec.
* The variable `window.location.hostname` does not include the port and therefore provides a valid domain for the cookie.

## How Has This Been Tested?

* Manually tested using dispatcher. You can for example use `docker run -d -p 8080:80 aem-dispatcher:latest` to start the dispatcher on port `8080` to reproduce the problem.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
