### PR TITLE
CIF-1624: Remove commons-text dependency in UrlProviderImpl

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -385,10 +385,6 @@
             <version>0.1.10</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
             <classifier>apis</classifier>

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImpl.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.text.StringSubstitutor;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Activate;
@@ -160,6 +159,26 @@ public class UrlProviderImpl implements UrlProvider {
             return request.getRequestPathInfo().getSuffix().substring(1); // Remove leading /
         } else {
             throw new RuntimeException("Identifier location " + identifierLocation + " is not supported");
+        }
+    }
+
+    static class StringSubstitutor {
+
+        private final String[] searchList;
+        private final String[] replacementList;
+
+        public StringSubstitutor(Map<String, String> params, String prefix, String suffix) {
+            replacementList = params.values().toArray(new String[0]);
+            searchList = params.keySet().toArray(new String[0]);
+            if (StringUtils.isNotBlank(prefix) && StringUtils.isNotBlank(suffix)) {
+                for (int i = 0; i < searchList.length; ++i) {
+                    searchList[i] = prefix + searchList[i] + suffix;
+                }
+            }
+        }
+
+        public String replace(String source) {
+            return StringUtils.replaceEach(source, searchList, replacementList);
         }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImplTest.java
@@ -14,6 +14,7 @@
 
 package com.adobe.cq.commerce.core.components.internal.services;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -185,5 +186,23 @@ public class UrlProviderImplTest {
         Pair<ProductIdentifierType, String> id = urlProvider.getProductIdentifier(context.request());
         Assert.assertEquals(ProductIdentifierType.SKU, id.getLeft());
         Assert.assertEquals("MJ01", id.getRight());
+    }
+
+    @Test
+    public void testStringSubstitutor() {
+        Map<String, String> params = new HashMap<>();
+
+        // empty params, valid prefix & suffix
+        UrlProviderImpl.StringSubstitutor sub = new UrlProviderImpl.StringSubstitutor(params, "${", "}");
+        Assert.assertEquals("Wrong substitution", "${test}", sub.replace("${test}"));
+
+        // valid params, no prefix & suffix
+        params.put("test", "value");
+        sub = new UrlProviderImpl.StringSubstitutor(params, null, null);
+        Assert.assertEquals("Wrong substitution", "${value}-value", sub.replace("${test}-test"));
+
+        // valid params, prefix & suffix
+        sub = new UrlProviderImpl.StringSubstitutor(params, "${", "}");
+        Assert.assertEquals("Wrong substitution", "value-value", sub.replace("${test}-${test}"));
     }
 }

--- a/examples/bundle/pom.xml
+++ b/examples/bundle/pom.xml
@@ -445,11 +445,6 @@
             <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <developers>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -960,12 +960,6 @@
                 <version>${core.wcm.components.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>1.8</version>
-                <scope>provided</scope>
-            </dependency>
 
             <!-- Testing -->
             <dependency>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -91,12 +91,6 @@
                     </dependencies>
                     
                     <embeddedTarget>/apps/bundles/install</embeddedTarget>
-                    <embeddeds> 
-                        <embedded>
-                            <groupId>org.apache.commons</groupId>
-                            <artifactId>commons-text</artifactId>
-                        </embedded>
-                    </embeddeds>
                 </configuration>
             </plugin>
 
@@ -166,10 +160,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.content</artifactId>


### PR DESCRIPTION
## Description

This PR replaces the use of `StringSubstitutor.replace()` in `UrlProviderImpl` with `StringUtils` methods to avoid adding dependency on Apache's `commons-text` package.

## Motivation and Context

The `commons-text` bundle was embedded in `ui.apps` package. Embedding 3rd party bundles in application type package is now prohibitted for AEM as a Cloud Service.

## How Has This Been Tested?

- unit tests

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
