### PR TITLE
CIF-1644 - GraphQL requests for staged data should use POST

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
@@ -166,6 +166,9 @@ public class MagentoGraphqlClient {
                 OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(liveDate.toInstant(), timeZone.toZoneId());
                 Long previewVersion = offsetDateTime.toEpochSecond();
                 headers.add(new BasicHeader("Preview-Version", String.valueOf(previewVersion)));
+
+                // We use POST to ensure that Magento doesn't return a cached response
+                requestOptions.withHttpMethod(HttpMethod.POST);
             }
         }
 

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClientTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClientTest.java
@@ -214,7 +214,7 @@ public class MagentoGraphqlClientTest {
         headers.add(new BasicHeader("Store", "my-store"));
         headers.add(new BasicHeader("Preview-Version", "1606809600")); // Tuesday, 1 December 2020 09:00:00 GMT+01:00
 
-        RequestOptionsMatcher matcher = new RequestOptionsMatcher(headers, null);
+        RequestOptionsMatcher matcher = new RequestOptionsMatcher(headers, HttpMethod.POST);
         Mockito.verify(graphqlClient).execute(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.argThat(matcher));
     }
 


### PR DESCRIPTION
This is a workaround to ensure that Magento does not return a cached response for staged data.

## How Has This Been Tested?

Manually tested.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
