### PR TITLE
CIF-1084 - Implement the password reset page

### DIFF
--- a/react-components/i18n/en/account.json
+++ b/react-components/i18n/en/account.json
@@ -43,5 +43,11 @@
   "address-default-tag": "Default",
   "address-form-heading": "Address",
   "account-information": "Account Information",
-  "reset-password-instructions": "Enter your email below to receive a password reset link."
+  "reset-password-instructions": "Enter your email below to receive a password reset link.",
+  "reset-password-lead": "Please choose a new password to complete the password reset.",
+  "new-password-confirm": "Confirm new Password",
+  "reset-password": "Reset Password",
+  "reset-password-missing-token": "Missing or invalid token.",
+  "reset-password-error": "Could not reset password.",
+  "reset-password-success": "Your password was changed. Please log in with your new password."
 }

--- a/react-components/package-lock.json
+++ b/react-components/package-lock.json
@@ -5284,12 +5284,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-      "dev": true
-    },
     "gulp-sort": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-sort/-/gulp-sort-2.0.0.tgz",
@@ -7195,14 +7189,13 @@
       "dev": true
     },
     "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
       }
     },
     "mini-css-extract-plugin": {
@@ -8518,16 +8511,16 @@
       "dev": true
     },
     "react-router": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
-      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
+        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
@@ -8536,16 +8529,16 @@
       }
     },
     "react-router-dom": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.1.2",
+        "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }

--- a/react-components/src/components/ForgotPassword/forgotPasswordForm.js
+++ b/react-components/src/components/ForgotPassword/forgotPasswordForm.js
@@ -16,7 +16,8 @@ import { func, shape, string } from 'prop-types';
 import { Form } from 'informed';
 import { useTranslation } from 'react-i18next';
 
-import { isRequired } from '../../utils/formValidators';
+import combine from '../../utils/combineValidators';
+import { isRequired, validateEmail } from '../../utils/formValidators';
 import Field from '../Field';
 import TextInput from '../TextInput';
 import Button from '../Button';
@@ -35,7 +36,7 @@ const ForgotPasswordForm = props => {
                 <TextInput
                     autoComplete="email"
                     field="email"
-                    validate={isRequired}
+                    validate={combine([isRequired, validateEmail])}
                     validateOnBlur
                     aria-label="email"></TextInput>
             </Field>

--- a/react-components/src/components/ResetPassword/ResetPassword.css
+++ b/react-components/src/components/ResetPassword/ResetPassword.css
@@ -1,0 +1,32 @@
+.root {
+    padding: 1rem;
+}
+
+.fields {
+    max-width: 300px;
+}
+
+.lead {
+    background-color: rgb(var(--venia-grey));
+    border-radius: 4px;
+    font-size: 0.875rem;
+    font-weight: 300;
+    line-height: 1.25rem;
+    padding: 1rem;
+    margin: 1rem 0 1rem 0;
+}
+
+.submit {
+    padding-top: 1rem;
+}
+
+.error {
+    color: rgb(var(--venia-error));
+    background-color: rgb(var(--venia-grey));
+    border-radius: 4px;
+    font-size: 0.875rem;
+    font-weight: 300;
+    line-height: 1.25rem;
+    padding: 1rem;
+    margin: 1rem 0 1rem 0;
+}

--- a/react-components/src/components/ResetPassword/ResetPassword.js
+++ b/react-components/src/components/ResetPassword/ResetPassword.js
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+import React from 'react';
+import { Form } from 'informed';
+import { useTranslation } from 'react-i18next';
+
+import { useQueryParams } from '../../utils/hooks';
+import Field from '../Field';
+import TextInput from '../TextInput';
+import Button from '../Button';
+import combine from '../../utils/combineValidators';
+import {
+    isRequired,
+    validateEmail,
+    validatePassword,
+    validateConfirmPassword,
+    hasLengthAtLeast
+} from '../../utils/formValidators';
+import useResetPassword from './useResetPassword';
+import LoadingIndicator from '../LoadingIndicator';
+
+import classes from './ResetPassword.css';
+
+const ResetPassword = () => {
+    const [t] = useTranslation('account', 'common');
+    const queryParams = useQueryParams();
+    const token = queryParams.get('token');
+    const [status, { handleFormSubmit }] = useResetPassword();
+
+    const onSubmit = formValues => {
+        const { email, password } = formValues;
+        handleFormSubmit({ email, password, token });
+    };
+
+    if (!token) {
+        return (
+            <div className={classes.error}>
+                {t('account:reset-password-missing-token', 'Missing or invalid token.')}
+            </div>
+        );
+    }
+
+    if (status === 'loading') {
+        return <LoadingIndicator>{t('common:loading', 'Loading')}</LoadingIndicator>;
+    }
+
+    if (status === 'error') {
+        return <div className={classes.error}>{t('account:reset-password-error', 'Could not reset password.')}</div>;
+    }
+
+    if (status === 'done') {
+        return (
+            <div className={classes.root}>
+                <p className={classes.lead}>
+                    {t(
+                        'account:reset-password-success',
+                        'Your password was changed. Please log in with your new password.'
+                    )}
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <Form className={classes.root} onSubmit={onSubmit}>
+            <p className={classes.lead}>
+                {t('account:reset-password-lead', 'Please choose a new password to complete the password reset.')}
+            </p>
+            <div className={classes.fields}>
+                <Field label={t('account:email', 'Email address')} required={true}>
+                    <TextInput
+                        field="email"
+                        autoComplete="email"
+                        validate={combine([isRequired, validateEmail])}
+                        validateOnBlur
+                        aria-label="email"
+                    />
+                </Field>
+                <Field label={t('account:new-password', 'New Password')} required={true}>
+                    <TextInput
+                        field="password"
+                        type="password"
+                        autoComplete="new-password"
+                        validate={combine([isRequired, [hasLengthAtLeast, 8], validatePassword])}
+                        validateOnBlur
+                        aria-label="password"
+                    />
+                </Field>
+                <Field label={t('account:new-password-confirm', 'Confirm new Password')} required={true}>
+                    <TextInput
+                        field="confirm"
+                        type="password"
+                        validate={combine([isRequired, validateConfirmPassword])}
+                        validateOnBlur
+                        aria-label="confirm"
+                    />
+                </Field>
+            </div>
+            <div className={classes.submit}>
+                <Button type="submit" priority="high" aria-label="submit">
+                    {t('account:reset-password', 'Reset Password')}
+                </Button>
+            </div>
+        </Form>
+    );
+};
+
+export default ResetPassword;

--- a/react-components/src/components/ResetPassword/__test__/ResetPassword.test.js
+++ b/react-components/src/components/ResetPassword/__test__/ResetPassword.test.js
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+import React from 'react';
+import { render, fireEvent, waitForElement } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { MockedProvider } from '@apollo/react-testing';
+
+import MUTATION_RESET_PASSWORD from '../../../queries/mutation_reset_password.graphql';
+
+const mockQueryParams = { get: jest.fn() };
+jest.mock('../../../utils/hooks', () => ({
+    useQueryParams: () => mockQueryParams
+}));
+
+import ResetPassword from '../ResetPassword';
+import i18n from '../../../../__mocks__/i18nForTests';
+
+describe('ResetPassword', () => {
+    afterEach(() => {
+        mockQueryParams.get.mockReset();
+    });
+
+    it('renders the form', () => {
+        mockQueryParams.get.mockReturnValue('mytoken');
+        const { asFragment } = render(
+            <I18nextProvider i18n={i18n}>
+                <MockedProvider>
+                    <ResetPassword />
+                </MockedProvider>
+            </I18nextProvider>
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('renders an error message for a missing token', () => {
+        mockQueryParams.get.mockReturnValue(null);
+        const { asFragment } = render(
+            <I18nextProvider i18n={i18n}>
+                <MockedProvider>
+                    <ResetPassword />
+                </MockedProvider>
+            </I18nextProvider>
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('renders an error message for a failed password reset', async () => {
+        mockQueryParams.get.mockReturnValue('mytoken');
+        const mocks = [
+            {
+                request: {
+                    query: MUTATION_RESET_PASSWORD,
+                    variables: {
+                        email: 'chuck@example.com',
+                        resetPasswordToken: 'mytoken',
+                        newPassword: 'NewPassword123'
+                    }
+                },
+                result: {
+                    data: { resetPassword: false },
+                    errors: [{ message: 'Cannot set the customers password' }]
+                }
+            }
+        ];
+
+        const { asFragment, getByLabelText, getByText } = render(
+            <I18nextProvider i18n={i18n}>
+                <MockedProvider mocks={mocks} addTypename={false}>
+                    <ResetPassword />
+                </MockedProvider>
+            </I18nextProvider>
+        );
+
+        fireEvent.change(getByLabelText('email'), { target: { value: 'chuck@example.com' } });
+        fireEvent.change(getByLabelText('password'), { target: { value: 'NewPassword123' } });
+        fireEvent.change(getByLabelText('confirm'), { target: { value: 'NewPassword123' } });
+        fireEvent.click(getByLabelText('submit'));
+
+        await waitForElement(() => getByText('Could not reset password.'));
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('renders a success message', async () => {
+        mockQueryParams.get.mockReturnValue('mytoken');
+        const mocks = [
+            {
+                request: {
+                    query: MUTATION_RESET_PASSWORD,
+                    variables: {
+                        email: 'chuck@example.com',
+                        resetPasswordToken: 'mytoken',
+                        newPassword: 'NewPassword123'
+                    }
+                },
+                result: {
+                    data: { resetPassword: true }
+                }
+            }
+        ];
+
+        const { asFragment, getByLabelText, getByText } = render(
+            <I18nextProvider i18n={i18n}>
+                <MockedProvider mocks={mocks} addTypename={false}>
+                    <ResetPassword />
+                </MockedProvider>
+            </I18nextProvider>
+        );
+
+        fireEvent.change(getByLabelText('email'), { target: { value: 'chuck@example.com' } });
+        fireEvent.change(getByLabelText('password'), { target: { value: 'NewPassword123' } });
+        fireEvent.change(getByLabelText('confirm'), { target: { value: 'NewPassword123' } });
+        fireEvent.click(getByLabelText('submit'));
+
+        await waitForElement(() => getByText('Your password was changed. Please log in with your new password.'));
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/react-components/src/components/ResetPassword/__test__/__snapshots__/ResetPassword.test.js.snap
+++ b/react-components/src/components/ResetPassword/__test__/__snapshots__/ResetPassword.test.js.snap
@@ -1,0 +1,177 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResetPassword renders a success message 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+  >
+    <p
+      class="lead"
+    >
+      Your password was changed. Please log in with your new password.
+    </p>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ResetPassword renders an error message for a failed password reset 1`] = `
+<DocumentFragment>
+  <div
+    class="error"
+  >
+    Could not reset password.
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ResetPassword renders an error message for a missing token 1`] = `
+<DocumentFragment>
+  <div
+    class="error"
+  >
+    Missing or invalid token.
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ResetPassword renders the form 1`] = `
+<DocumentFragment>
+  <form
+    class="root"
+  >
+    <p
+      class="lead"
+    >
+      Please choose a new password to complete the password reset.
+    </p>
+    <div
+      class="fields"
+    >
+      <div
+        class="root"
+      >
+        <span
+          class="label"
+        >
+          <span
+            class="requiredSymbol"
+          />
+          Email address
+        </span>
+        <span
+          class="root"
+        >
+          <span
+            class="input"
+          >
+            <input
+              aria-label="email"
+              autocomplete="email"
+              class="input"
+              name="email"
+              value=""
+            />
+          </span>
+          <span
+            class="before"
+          />
+          <span
+            class="after"
+          />
+        </span>
+        <p
+          class="root"
+        />
+      </div>
+      <div
+        class="root"
+      >
+        <span
+          class="label"
+        >
+          <span
+            class="requiredSymbol"
+          />
+          New Password
+        </span>
+        <span
+          class="root"
+        >
+          <span
+            class="input"
+          >
+            <input
+              aria-label="password"
+              autocomplete="new-password"
+              class="input"
+              name="password"
+              type="password"
+              value=""
+            />
+          </span>
+          <span
+            class="before"
+          />
+          <span
+            class="after"
+          />
+        </span>
+        <p
+          class="root"
+        />
+      </div>
+      <div
+        class="root"
+      >
+        <span
+          class="label"
+        >
+          <span
+            class="requiredSymbol"
+          />
+          Confirm new Password
+        </span>
+        <span
+          class="root"
+        >
+          <span
+            class="input"
+          >
+            <input
+              aria-label="confirm"
+              class="input"
+              name="confirm"
+              type="password"
+              value=""
+            />
+          </span>
+          <span
+            class="before"
+          />
+          <span
+            class="after"
+          />
+        </span>
+        <p
+          class="root"
+        />
+      </div>
+    </div>
+    <div
+      class="submit"
+    >
+      <button
+        aria-label="submit"
+        class="root_highPriority"
+        type="submit"
+      >
+        <span
+          class="content"
+        >
+          Reset Password
+        </span>
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;

--- a/react-components/src/components/ResetPassword/index.js
+++ b/react-components/src/components/ResetPassword/index.js
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+export { default } from './ResetPassword';

--- a/react-components/src/components/ResetPassword/useResetPassword.js
+++ b/react-components/src/components/ResetPassword/useResetPassword.js
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+import { useState, useCallback } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+
+import MUTATION_RESET_PASSWORD from '../../queries/mutation_reset_password.graphql';
+
+const useResetPassword = () => {
+    const [status, setStatus] = useState('new');
+
+    const [resetPassword] = useMutation(MUTATION_RESET_PASSWORD);
+
+    const handleFormSubmit = useCallback(
+        async ({ email, token, password }) => {
+            setStatus('loading');
+            try {
+                await resetPassword({ variables: { email, resetPasswordToken: token, newPassword: password } });
+                setStatus('done');
+            } catch (err) {
+                setStatus('error');
+            }
+        },
+        [resetPassword]
+    );
+
+    return [status, { handleFormSubmit }];
+};
+
+export default useResetPassword;

--- a/react-components/src/index.js
+++ b/react-components/src/index.js
@@ -19,6 +19,7 @@ export { default as AccountContainer } from './components/AccountContainer';
 export { default as AddressBook } from './components/AddressBook';
 export { default as BundleProductOptions } from './components/BundleProductOptions';
 export { default as Portal } from './components/Portal';
+export { default as ResetPassword } from './components/ResetPassword';
 
 export { default as ConfigContextProvider, useConfigContext } from './context/ConfigContext';
 export { default as UserContextProvider, useUserContext } from './context/UserContext';

--- a/react-components/src/queries/mutation_reset_password.graphql
+++ b/react-components/src/queries/mutation_reset_password.graphql
@@ -1,0 +1,3 @@
+mutation($email: String!, $resetPasswordToken: String!, $newPassword: String!) {
+    resetPassword(email: $email, resetPasswordToken: $resetPasswordToken, newPassword: $newPassword)
+}

--- a/react-components/src/utils/__test__/hooks.test.js
+++ b/react-components/src/utils/__test__/hooks.test.js
@@ -16,7 +16,8 @@ import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { render, waitForElement } from '@testing-library/react';
 
-import { useCountries } from '../hooks';
+import { useCountries, useQueryParams } from '../hooks';
+
 import QUERY_COUNTRIES from '../../queries/query_countries.graphql';
 
 const mocks = [
@@ -71,6 +72,17 @@ describe('Custom hooks', () => {
             const [count, result] = await waitForElement(() => [getByTestId('count'), getByTestId('result')]);
             expect(count.textContent).toEqual('2');
             expect(result.textContent).toEqual('US');
+        });
+    });
+
+    describe('useQueryParams', () => {
+        it('returns a URLSearchParams object', () => {
+            delete window.location;
+            window.location = new URL('http://localhost?token=my-token&page=5');
+
+            const queryParams = useQueryParams();
+            expect(queryParams.get('token')).toEqual('my-token');
+            expect(queryParams.get('page')).toEqual('5');
         });
     });
 });

--- a/react-components/src/utils/hooks.js
+++ b/react-components/src/utils/hooks.js
@@ -72,3 +72,11 @@ export const useAwaitQuery = query => {
         [apolloClient, query]
     );
 };
+
+/**
+ * This hook makes the query parameters of the URL available.
+ */
+export const useQueryParams = () => {
+    // Better to use useLocation from react router here, but this doesn't work because of dependency mess up.
+    return new URLSearchParams(window.location.search);
+};

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/resetpassword/v1/resetpassword/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/resetpassword/v1/resetpassword/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:title="Reset Password Form"
+    componentGroup=".hidden"
+    jcr:primaryType="cq:Component"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/resetpassword/v1/resetpassword/resetpassword.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/resetpassword/v1/resetpassword/resetpassword.html
@@ -1,0 +1,16 @@
+<!--/*
+    Copyright 2020 Adobe Systems Incorporated
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/-->
+<div id="reset-password-page"></div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR depends on #400.

* Add new `ResetPassword` React component to display the reset password form.
* Add new `resetpassword` component to display the placeholder for the React component.
* Added unit tests.
* This feature requires setup on the Magento side, please see https://github.com/adobe/aem-core-cif-components/wiki/Configure-Reset-Password.

Please also see https://github.com/adobe/aem-cif-guides-venia/pull/60.

## How Has This Been Tested?

* Manually tested password reset workflow.
* Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
