### PR TITLE
CIF-1653 - TTL-based caching is skipped by the SpecificPageFilterFactory

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/SpecificPageFilterFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/SpecificPageFilterFactory.java
@@ -38,7 +38,8 @@ import com.day.cq.wcm.api.WCMMode;
     property = {
         "sling.filter.scope=REQUEST",
         "sling.filter.methods=GET",
-        "sling.filter.extensions=html"
+        "sling.filter.extensions=html",
+        "service.ranking:Integer=" + Integer.MIN_VALUE
     })
 @Designate(ocd = SpecificPageFilterConfiguration.class, factory = true)
 public class SpecificPageFilterFactory implements Filter {


### PR DESCRIPTION
- configure filter ranking to lowest possible value, to avoid skipping the DispatcherCacheHeaderFilter filters from ACS-Commons

## Motivation and Context

When it matches, the `SpecificPageFilterFactory` forwards the request to another page, and this "breaks" the chain of filters. We hence set the ranking to the lowest possible value, in particular to avoid skipping the TTL-based filters.

## How Has This Been Tested?

Manually tested with dispatcher and ACS-Commons filters.

## Screenshots (if appropriate):

![Screenshot 2020-09-30 at 12 59 25](https://user-images.githubusercontent.com/24548615/94677293-f50a6980-031c-11eb-8afb-50433df1f2eb.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
