### PR TITLE
CIF-1680 - Add htl-maven-plugin to CIF ui.apps

### DIFF
--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -154,6 +154,21 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>htl-maven-plugin</artifactId>
+                <version>2.0.2-1.4.0</version>
+                <configuration>
+                    <sourceDirectory>src/main/content/jcr_root/apps/core/cif/components</sourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
- only enabled the validation of scripts, not the generation and compilation of scripts in java (IMHO it doesn't bring much).