### PR TITLE
CIF-1713 - [CIF Connector] Add support for urlPath property in catego…

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/postprocessor/SelectorFilterPostProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/postprocessor/SelectorFilterPostProcessor.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ *
+ *    Copyright 2020 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.core.components.internal.postprocessor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestParameter;
+import org.apache.sling.api.request.RequestParameterMap;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.servlets.post.Modification;
+import org.apache.sling.servlets.post.SlingPostProcessor;
+import org.osgi.service.component.annotations.Component;
+
+import static com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.SELECTOR_FILTER_PROPERTY;
+import static com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.URL_PATH_PROPERTY;
+
+@Component(service = { SlingPostProcessor.class })
+public class SelectorFilterPostProcessor implements SlingPostProcessor {
+
+    private static final String SLING_PROPERTY_PREFIX = "./";
+    private static final String ID_AND_URL_PATH_SEPARATOR = "|";
+
+    @Override
+    public void process(SlingHttpServletRequest request, List<Modification> modifications) throws Exception {
+
+        RequestParameterMap requestParameterMap = request.getRequestParameterMap();
+        if (!requestParameterMap.containsKey(SLING_PROPERTY_PREFIX + SELECTOR_FILTER_PROPERTY)) {
+            return;
+        }
+
+        Resource resource = request.getResource();
+        ModifiableValueMap properties = resource.adaptTo(ModifiableValueMap.class);
+
+        // We always first remove the properties to allow changes from String to String arrays (see below)
+        properties.remove(SELECTOR_FILTER_PROPERTY);
+        properties.remove(URL_PATH_PROPERTY);
+
+        RequestParameter[] params = requestParameterMap.getValues(SLING_PROPERTY_PREFIX + SELECTOR_FILTER_PROPERTY);
+
+        if (params.length == 1) {
+            String selectorFilter = params[0].getString();
+            if (!StringUtils.contains(selectorFilter, ID_AND_URL_PATH_SEPARATOR)) {
+                return;
+            }
+
+            // There is only a single value, so we store the two properties as Strings
+            properties.put(SELECTOR_FILTER_PROPERTY, StringUtils.substringBefore(selectorFilter, ID_AND_URL_PATH_SEPARATOR));
+            properties.put(URL_PATH_PROPERTY, StringUtils.substringAfter(selectorFilter, ID_AND_URL_PATH_SEPARATOR));
+        } else {
+            // There are multiple values, so we store the two properties as String arrays
+            List<String> ids = new ArrayList<>();
+            List<String> urlPaths = new ArrayList<>();
+
+            for (RequestParameter param : params) {
+                String selectorFilter = param.getString();
+                if (!StringUtils.contains(selectorFilter, ID_AND_URL_PATH_SEPARATOR)) {
+                    continue;
+                }
+
+                ids.add(StringUtils.substringBefore(selectorFilter, ID_AND_URL_PATH_SEPARATOR));
+                urlPaths.add(StringUtils.substringAfter(selectorFilter, ID_AND_URL_PATH_SEPARATOR));
+            }
+
+            properties.put(SELECTOR_FILTER_PROPERTY, ids.toArray());
+            properties.put(URL_PATH_PROPERTY, urlPaths.toArray());
+        }
+
+        modifications.add(Modification.onModified(resource.getPath()));
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImpl.java
@@ -42,8 +42,8 @@ public class UrlProviderImpl implements UrlProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UrlProviderImpl.class);
 
-    private static final String SELECTOR_FILTER_PROPERTY = "selectorFilter";
-    private static final String URL_PATH_PROPERTY = "urlPath";
+    public static final String SELECTOR_FILTER_PROPERTY = "selectorFilter";
+    public static final String URL_PATH_PROPERTY = "urlPath";
     private static final String INCLUDES_SUBCATEGORIES_PROPERTY = "includesSubCategories";
 
     private String productUrlTemplate;

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/postprocessor/SelectorFilterPostProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/postprocessor/SelectorFilterPostProcessorTest.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ *
+ *    Copyright 2020 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.core.components.internal.postprocessor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
+import org.apache.sling.servlets.post.Modification;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit.AemContextCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SelectorFilterPostProcessorTest {
+
+    @Rule
+    public final AemContext context = createContext("/context/selector-filter-post-processor.json");
+
+    private static AemContext createContext(String contentPath) {
+        return new AemContext(
+            (AemContextCallback) context -> {
+                // Load page structure
+                context.load().json(contentPath, "/content");
+            },
+            ResourceResolverType.JCR_MOCK);
+    }
+
+    @Test
+    public void testMissingRequestParameter() throws Exception {
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        request.setResource(context.resourceResolver().resolve("/content/empty/jcr:content"));
+
+        SelectorFilterPostProcessor postProcessor = new SelectorFilterPostProcessor();
+        List<Modification> modifications = new ArrayList<>();
+        postProcessor.process(request, modifications);
+
+        assertThat(modifications).isEmpty();
+    }
+
+    @Test
+    public void testMissingSelectorFilterSeparator() throws Exception {
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        request.setResource(context.resourceResolver().resolve("/content/empty/jcr:content"));
+        request.setParameterMap(Collections.singletonMap("./selectorFilter", "1"));
+
+        SelectorFilterPostProcessor postProcessor = new SelectorFilterPostProcessor();
+        List<Modification> modifications = new ArrayList<>();
+        postProcessor.process(request, modifications);
+
+        assertThat(modifications).isEmpty();
+    }
+
+    @Test
+    public void testPostToEmptyResource() throws Exception {
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        request.setResource(context.resourceResolver().resolve("/content/empty/jcr:content"));
+        request.setParameterMap(Collections.singletonMap("./selectorFilter", "1|men"));
+
+        SelectorFilterPostProcessor postProcessor = new SelectorFilterPostProcessor();
+        List<Modification> modifications = new ArrayList<>();
+        postProcessor.process(request, modifications);
+        Resource resource = request.getResource();
+
+        assertThat(modifications)
+            .isNotEmpty()
+            .hasSize(1);
+
+        ValueMap vm = resource.getValueMap();
+        assertThat(vm)
+            .isNotEmpty()
+            .containsKeys("selectorFilter", "urlPath");
+
+        assertThat(vm.get("selectorFilter", String.class)).isEqualTo("1");
+        assertThat(vm.get("urlPath", String.class)).isEqualTo("men");
+    }
+
+    @Test
+    public void testChangeSingleValueToMultiValues() throws Exception {
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        request.setResource(context.resourceResolver().resolve("/content/singlevalue/jcr:content"));
+        request.setParameterMap(Collections.singletonMap("./selectorFilter", new String[] { "1|men", "2|women", "invalid" }));
+
+        SelectorFilterPostProcessor postProcessor = new SelectorFilterPostProcessor();
+        List<Modification> modifications = new ArrayList<>();
+        postProcessor.process(request, modifications);
+        Resource resource = request.getResource();
+
+        assertThat(modifications)
+            .isNotEmpty()
+            .hasSize(1);
+
+        ValueMap vm = resource.getValueMap();
+        assertThat(vm)
+            .isNotEmpty()
+            .containsKeys("selectorFilter", "urlPath");
+
+        assertThat(vm.get("selectorFilter", String[].class)).contains("1", "2");
+        assertThat(vm.get("urlPath", String[].class)).contains("men", "women");
+    }
+
+    @Test
+    public void testChangeMultiValuesToSingleValue() throws Exception {
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        request.setResource(context.resourceResolver().resolve("/content/singlevalue/jcr:content"));
+        request.setParameterMap(Collections.singletonMap("./selectorFilter", "0|root"));
+
+        SelectorFilterPostProcessor postProcessor = new SelectorFilterPostProcessor();
+        List<Modification> modifications = new ArrayList<>();
+        postProcessor.process(request, modifications);
+        Resource resource = request.getResource();
+
+        assertThat(modifications)
+            .isNotEmpty()
+            .hasSize(1);
+
+        ValueMap vm = resource.getValueMap();
+        assertThat(vm)
+            .isNotEmpty()
+            .containsKeys("selectorFilter", "urlPath");
+
+        assertThat(vm.get("selectorFilter", String.class)).isEqualTo("0");
+        assertThat(vm.get("urlPath", String.class)).isEqualTo("root");
+    }
+}

--- a/bundles/core/src/test/resources/context/selector-filter-post-processor.json
+++ b/bundles/core/src/test/resources/context/selector-filter-post-processor.json
@@ -1,0 +1,24 @@
+{
+  "empty": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent"
+    }
+  },
+  "singlevalue": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "selectorFilter": "0",
+      "urlPath": "root"
+    }
+  },
+  "multivalues": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "selectorFilter": ["1", "2"],
+      "urlPath": ["men", "women"]
+    }
+  }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -110,11 +110,24 @@
                                                 fieldLabel="Category ids for which this page will be used."
                                                 multiple="{Boolean}true"
                                                 name="./selectorFilter"
-                                                selectionId="id">
+                                                selectionId="idAndUrlPath">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>
                                             </categoryFilter>
+                                            <includesSubCategories
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                fieldDescription="Enable that specific page for this category and all its sub-categories."
+                                                name="./includesSubCategories"
+                                                text="Include sub-categories"
+                                                uncheckedValue="false"
+                                                value="true">
+                                                <granite:rendercondition
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="core/cif/components/renderconditions/pagetype"
+                                                    pageType="category"/>
+                                            </includesSubCategories>
                                             <productFilter jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                 fieldDescription="Product slugs for which this page will be used."


### PR DESCRIPTION
…ry picker

- add a sling post-processor to save the selectorFilter and urlPath properties for category specific pages

## Description

The post-processor is added to process the combined `idAndUrlPath` option added in the category picker by https://github.com/adobe/commerce-cif-connector/pull/155

## How Has This Been Tested?

Added unit tests and manually tested.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
