### PR TITLE
CIF-1614 - implement optional usage for publish server graphql reverse proxy

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
@@ -85,7 +85,7 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
 
         // use the AEM publish server endpoint absolut URL only on author, if configured and if endpoint is not already an absolut URL
         usePublishGraphqlEndpoint = properties.get(USE_PUBLISH_GRAPHQL_ENDPOINT_PROPERTY, false) && slingSettings.getRunModes().contains(
-            "author") && !StringUtils.startsWith(graphqlEndpoint, "http");
+            "author") && !StringUtils.startsWith(graphqlEndpoint, "http") && !StringUtils.startsWith(graphqlEndpoint, "//");
 
         // Get configuration from GraphQL client
         MagentoGraphqlClient magentoGraphqlClient = MagentoGraphqlClient.create(resource, currentPage, request);

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
@@ -52,9 +52,13 @@ public class StoreConfigExporterTest {
     private static final ValueMap MOCK_CONFIGURATION_3 = new ValueMapDecorator(
         ImmutableMap.of("magentoGraphqlEndpoint", "https://www.magento.com/my/magento/graphql", "magentoStore", "my-magento-store",
             "cq:graphqlClient", "my-graphql-client", "usePublishGraphqlEndpoint", true));
+    private static final ValueMap MOCK_CONFIGURATION_4 = new ValueMapDecorator(
+        ImmutableMap.of("magentoGraphqlEndpoint", "//localhost:3002/graphql", "magentoStore", "my-magento-store",
+            "cq:graphqlClient", "my-graphql-client", "usePublishGraphqlEndpoint", true));
     private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT_1 = new ComponentsConfiguration(MOCK_CONFIGURATION_1);
     private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT_2 = new ComponentsConfiguration(MOCK_CONFIGURATION_2);
     private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT_3 = new ComponentsConfiguration(MOCK_CONFIGURATION_3);
+    private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT_4 = new ComponentsConfiguration(MOCK_CONFIGURATION_4);
 
     @Rule
     public final AemContext context = createContext("/context/jcr-content.json");
@@ -71,6 +75,8 @@ public class StoreConfigExporterTest {
                             return MOCK_CONFIGURATION_OBJECT_2;
                         } else if (input.getPath().contains("pageJ")) {
                             return MOCK_CONFIGURATION_OBJECT_3;
+                        } else if (input.getPath().contains("pageK")) {
+                            return MOCK_CONFIGURATION_OBJECT_4;
                         } else {
                             return ComponentsConfiguration.EMPTY;
                         }
@@ -142,12 +148,21 @@ public class StoreConfigExporterTest {
     }
 
     @Test
-    public void testAbsolutGraphqlEndpointUsePublishOnAuthor() {
+    public void testAbsolutGraphqlEndpointUsePublishOnAuthor1() {
         context.runMode("publish");
         setupWithPage("/content/pageJ", HttpMethod.POST);
         StoreConfigExporterImpl storeConfigExporter = context.request().adaptTo(StoreConfigExporterImpl.class);
 
         Assert.assertEquals("https://www.magento.com/my/magento/graphql", storeConfigExporter.getGraphqlEndpoint());
+    }
+
+    @Test
+    public void testAbsolutGraphqlEndpointUsePublishOnAuthor2() {
+        context.runMode("publish");
+        setupWithPage("/content/pageK", HttpMethod.POST);
+        StoreConfigExporterImpl storeConfigExporter = context.request().adaptTo(StoreConfigExporterImpl.class);
+
+        Assert.assertEquals("//localhost:3002/graphql", storeConfigExporter.getGraphqlEndpoint());
     }
 
     @Test

--- a/bundles/core/src/test/resources/context/jcr-content.json
+++ b/bundles/core/src/test/resources/context/jcr-content.json
@@ -225,6 +225,13 @@
       "cq:conf": "/conf/testing"
     }
   },
+  "pageK": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "cq:conf": "/conf/testing"
+    }
+  },
   "product-page": {
     "jcr:primaryType": "cq:Page",
     "jcr:content": {

--- a/bundles/core/src/test/resources/context/jcr-content.json
+++ b/bundles/core/src/test/resources/context/jcr-content.json
@@ -211,6 +211,20 @@
       "cq:conf": "/conf/testing"
     }
   },
+  "pageI": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "cq:conf": "/conf/testing"
+    }
+  },
+  "pageJ": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "cq:conf": "/conf/testing"
+    }
+  },
   "product-page": {
     "jcr:primaryType": "cq:Page",
     "jcr:content": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implement usage for Publish server GraphQL reverse proxy on AEM author instance. This is an optional feature, and mainly needed for AEM Cloud Services in combination with the provided reverse proxy solution for GraphQL calls to the commerce backend.

## Related Issue

CIF-1614

## Motivation and Context

Improve the GraphQL reverse proxy usage.

## How Has This Been Tested?

Added unit tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
