### PR TITLE
CIF-1815 - Remove redundant builds done in CircleCI integration tests jobs

### DIFF
--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -63,11 +63,13 @@ try {
 
     // Run integration tests
     if (TYPE === 'integration') {
-        ci.sh(`mvn clean verify -U -B \
-            -Ptest-all \
-            -Dsling.it.instance.url.1=http://localhost:4502 \
-            -Dsling.it.instance.runmode.1=author \
-            -Dsling.it.instances=1`);
+        ci.dir('it/http', () => {
+            ci.sh(`mvn clean verify -U -B \
+                -Ptest-all \
+                -Dsling.it.instance.url.1=http://localhost:4502 \
+                -Dsling.it.instance.runmode.1=author \
+                -Dsling.it.instances=1`);
+        });
     }
     
     // Run UI tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,10 @@ jobs:
           root: /home/circleci/build
           paths:
             - configuration.json
-            - bundles/core/target/*.jar
+            - bundles/core/target
             - ui.apps/target/*.zip
             - ui.config/target/*.zip
-            - examples/bundle/target/*.jar
+            - examples/bundle/target
             - examples/ui.apps/target/*.zip
             - examples/ui.config/target/*.zip
             - examples/ui.content/target/*.zip


### PR DESCRIPTION
This optimizes the CircleCI build and avoids rebuilding all maven modules when executing the integration tests. To generate the jacoco coverage for ITs, I simply also "store" the `target` folders for the two bundles so the classes are available when generating the jacoco report and there is no need to recompile anything.

Note that this reduces the build time by 3 to 5 minutes.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
