### PR TITLE
CIF-1918 - Query minification fails for /api/graphql endpoint

### DIFF
--- a/react-components/src/utils/compressQueryFetch.js
+++ b/react-components/src/utils/compressQueryFetch.js
@@ -25,13 +25,20 @@ import { stripIgnoredCharacters } from 'graphql';
 export default function(url, options) {
     try {
         if (options.method === 'GET') {
-            // Parse query from query string in URL
-            let parsedUrl = new URL(url);
-            let query = parsedUrl.searchParams.get('query');
-            if (query) {
-                query = stripIgnoredCharacters(query);
-                parsedUrl.searchParams.set('query', query);
-                url = parsedUrl.toString();
+            // Split url by ? to get query string
+            let parts = url.split('?');
+
+            // Only proceed if it is a valid URL
+            if (parts.length === 2) {
+                // Parse query from search params string
+                let params = new URLSearchParams(parts[1]);
+                let query = params.get('query');
+                if (query) {
+                    query = stripIgnoredCharacters(query);
+                    params.set('query', query);
+                    parts[1] = params.toString();
+                    url = parts.join('?');
+                }
             }
         }
         if (options.method === 'POST') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The GraphQL query compression that is used for GET requests fails for when the storefront is configured to use the `/api/graphql` endpoint.

This affects queries of the shopping cart and others.

## How Has This Been Tested?

* Manually tested with latest Venia snapshot
* Updated unit test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
