### PR TITLE
CIF-1955 - Venia ITs fail for productlist

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
@@ -430,11 +430,13 @@ public class ProductImpl extends DataLayerComponent implements Product {
 
     @Override
     public ComponentData getComponentData() {
+        resource = request.getResource();
         return new ProductDataImpl(this, resource);
     }
 
     @Override
     protected String generateId() {
+        resource = request.getResource();
         return StringUtils.join("product", ID_SEPARATOR, StringUtils.substring(DigestUtils.sha256Hex(getSku()), 0, 10));
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
@@ -49,6 +49,7 @@ import com.adobe.cq.commerce.magento.graphql.CategoryInterface;
 import com.adobe.cq.commerce.magento.graphql.CategoryProducts;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQuery;
 import com.adobe.cq.sightly.SightlyWCMMode;
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 
 @Model(
     adaptables = SlingHttpServletRequest.class,
@@ -241,5 +242,17 @@ public class ProductListImpl extends ProductCollectionImpl implements ProductLis
     @Override
     public String getCanonicalUrl() {
         return canonicalUrl;
+    }
+
+    @Override
+    protected String generateId() {
+        resource = request.getResource();
+        return super.generateId();
+    }
+
+    @Override
+    protected ComponentData getComponentData() {
+        resource = request.getResource();
+        return super.getComponentData();
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
@@ -15,7 +15,9 @@
 package com.adobe.cq.commerce.core.components.internal.models.v1.productlist;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -25,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -35,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
+import com.adobe.cq.commerce.core.components.internal.models.v1.common.ProductListItemImpl;
 import com.adobe.cq.commerce.core.components.internal.models.v1.productcollection.ProductCollectionImpl;
 import com.adobe.cq.commerce.core.components.models.common.ProductListItem;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductList;
@@ -184,7 +188,7 @@ public class ProductListImpl extends ProductCollectionImpl implements ProductLis
                 .filter(Objects::nonNull) // the converter returns null if the conversion fails
                 .collect(Collectors.toList());
         } else {
-            return getSearchResultsSet().getProductListItems();
+            return fixProducts(getSearchResultsSet().getProductListItems());
         }
     }
 
@@ -242,6 +246,36 @@ public class ProductListImpl extends ProductCollectionImpl implements ProductLis
     @Override
     public String getCanonicalUrl() {
         return canonicalUrl;
+    }
+
+    // TODO: This a temporary fix to solve an issue caused by SlingModel caching
+    private Collection<ProductListItem> fixedProducts;
+
+    private Collection<ProductListItem> fixProducts(Collection<ProductListItem> products) {
+        if (fixedProducts != null) {
+            return fixedProducts;
+        } else if (CollectionUtils.isEmpty(products)) {
+            fixedProducts = Collections.emptyList();
+            return fixedProducts;
+        }
+
+        resource = request.getResource();
+
+        fixedProducts = new ArrayList<>();
+        for (ProductListItem product : products) {
+            ProductListItem productListItem = new ProductListItemImpl(product.getSKU(),
+                product.getSlug(),
+                product.getTitle(),
+                product.getPriceRange(),
+                product.getImageURL(),
+                productPage,
+                null, // search results aren't targeting specific variant
+                request,
+                urlProvider,
+                this.getId());
+            fixedProducts.add(productListItem);
+        }
+        return fixedProducts;
     }
 
     @Override


### PR DESCRIPTION

This PR provides a workaround to fix an issue with Sling model caching with the datalayer. The fix is basically to "re-read" the `resource` when the datalayer data is generated to make sure that it uses the `productlist` component resource and not the page resource initially used when the component is instantiated in `PageMetadataImpl.java`.

The other part of the fix is to re-create the list of products to make sure that the resource types and paths are correct when generating the datalayer data.

These two fixes are a temporary workaround to fix the bug until the implementation is refactored to fix the issue in a nicer way.

## How Has This Been Tested?

See https://github.com/adobe/aem-cif-guides-venia/pull/104 and also manually tested.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
