### PR TITLE
CIF-1962 - Sling model caching introduces issues with PageMetadataImpl

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -416,7 +416,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.impl</artifactId>
-            <version>1.4.4</version>
+            <version>1.4.16</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/datalayer/AssetDataImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/datalayer/AssetDataImpl.java
@@ -14,6 +14,7 @@
 package com.adobe.cq.commerce.core.components.internal.datalayer;
 
 import java.util.Date;
+import java.util.Map;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +52,11 @@ public class AssetDataImpl implements AssetData {
 
     @Override
     public Date getLastModifiedDate() {
+        return null;
+    }
+
+    // Workaround until https://github.com/adobe/aem-core-wcm-components/issues/1415 is fixed
+    public Map<String, Object> getSmartTags() {
         return null;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImpl.java
@@ -15,13 +15,20 @@
 package com.adobe.cq.commerce.core.components.internal.models.v1.page;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.factory.ModelFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.adobe.cq.commerce.core.components.internal.models.v1.product.ProductImpl;
+import com.adobe.cq.commerce.core.components.internal.models.v1.productlist.ProductListImpl;
 import com.adobe.cq.commerce.core.components.models.page.PageMetadata;
 import com.adobe.cq.commerce.core.components.models.product.Product;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductList;
@@ -34,8 +41,13 @@ import com.day.cq.wcm.api.Page;
     adapters = PageMetadata.class)
 public class PageMetadataImpl implements PageMetadata {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(PageMetadataImpl.class);
+
     @Self
     private SlingHttpServletRequest request;
+
+    @Inject
+    protected Resource resource;
 
     @ScriptVariable
     private Page currentPage;
@@ -43,17 +55,41 @@ public class PageMetadataImpl implements PageMetadata {
     @ScriptVariable
     private ValueMap properties;
 
+    @Inject
+    private ModelFactory modelFactory;
+
     private PageMetadata provider;
 
     @PostConstruct
     void initModel() {
+        // We cannot directly adapt from the current request because this would wrongly inject the page resource
+        // into the product or productlist component.
+        // We hence use a dedicated method in modelFactory to inject the right component resource.
+
         if (SiteNavigation.isProductPage(currentPage)) {
-            Product product = request.adaptTo(Product.class);
+            Resource componentResource = findChildResourceWithType(resource, ProductImpl.RESOURCE_TYPE);
+            Product product = modelFactory.getModelFromWrappedRequest(request, componentResource, Product.class);
             provider = product;
         } else if (SiteNavigation.isCategoryPage(currentPage)) {
-            ProductList productList = request.adaptTo(ProductList.class);
+            Resource componentResource = findChildResourceWithType(resource, ProductListImpl.RESOURCE_TYPE);
+            ProductList productList = modelFactory.getModelFromWrappedRequest(request, componentResource, ProductList.class);
             provider = productList;
         }
+    }
+
+    private Resource findChildResourceWithType(Resource resource, String type) {
+        LOGGER.debug("Looking for child resource '{}' at {}", type, resource.getPath());
+        for (Resource child : resource.getChildren()) {
+            if (child.isResourceType(type)) {
+                LOGGER.debug("Found child resource '{}' at {}", type, child.getPath());
+                return child;
+            }
+            Resource productComponent = findChildResourceWithType(child, type);
+            if (productComponent != null) {
+                return productComponent;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImpl.java
@@ -77,16 +77,16 @@ public class PageMetadataImpl implements PageMetadata {
         }
     }
 
-    private Resource findChildResourceWithType(Resource resource, String type) {
-        LOGGER.debug("Looking for child resource '{}' at {}", type, resource.getPath());
-        for (Resource child : resource.getChildren()) {
+    private Resource findChildResourceWithType(Resource fromResource, String type) {
+        LOGGER.debug("Looking for child resource type '{}' from {}", type, fromResource.getPath());
+        for (Resource child : fromResource.getChildren()) {
             if (child.isResourceType(type)) {
-                LOGGER.debug("Found child resource '{}' at {}", type, child.getPath());
+                LOGGER.debug("Found child resource type '{}' at {}", type, child.getPath());
                 return child;
             }
-            Resource productComponent = findChildResourceWithType(child, type);
-            if (productComponent != null) {
-                return productComponent;
+            Resource resource = findChildResourceWithType(child, type);
+            if (resource != null) {
+                return resource;
             }
         }
         return null;

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
@@ -87,7 +87,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
     cache = true)
 public class ProductImpl extends DataLayerComponent implements Product {
 
-    protected static final String RESOURCE_TYPE = "core/cif/components/commerce/product/v1/product";
+    public static final String RESOURCE_TYPE = "core/cif/components/commerce/product/v1/product";
     protected static final String PLACEHOLDER_DATA = "product-component-placeholder-data.json";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProductImpl.class);
@@ -430,13 +430,11 @@ public class ProductImpl extends DataLayerComponent implements Product {
 
     @Override
     public ComponentData getComponentData() {
-        resource = request.getResource();
         return new ProductDataImpl(this, resource);
     }
 
     @Override
     protected String generateId() {
-        resource = request.getResource();
         return StringUtils.join("product", ID_SEPARATOR, StringUtils.substring(DigestUtils.sha256Hex(getSku()), 0, 10));
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
@@ -15,9 +15,7 @@
 package com.adobe.cq.commerce.core.components.internal.models.v1.productlist;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -27,7 +25,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -38,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
-import com.adobe.cq.commerce.core.components.internal.models.v1.common.ProductListItemImpl;
 import com.adobe.cq.commerce.core.components.internal.models.v1.productcollection.ProductCollectionImpl;
 import com.adobe.cq.commerce.core.components.models.common.ProductListItem;
 import com.adobe.cq.commerce.core.components.models.productlist.ProductList;
@@ -53,7 +49,6 @@ import com.adobe.cq.commerce.magento.graphql.CategoryInterface;
 import com.adobe.cq.commerce.magento.graphql.CategoryProducts;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQuery;
 import com.adobe.cq.sightly.SightlyWCMMode;
-import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 
 @Model(
     adaptables = SlingHttpServletRequest.class,
@@ -62,7 +57,7 @@ import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
     cache = true)
 public class ProductListImpl extends ProductCollectionImpl implements ProductList {
 
-    protected static final String RESOURCE_TYPE = "core/cif/components/commerce/productlist/v1/productlist";
+    public static final String RESOURCE_TYPE = "core/cif/components/commerce/productlist/v1/productlist";
     protected static final String PLACEHOLDER_DATA = "productlist-component-placeholder-data.json";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProductListImpl.class);
@@ -188,7 +183,7 @@ public class ProductListImpl extends ProductCollectionImpl implements ProductLis
                 .filter(Objects::nonNull) // the converter returns null if the conversion fails
                 .collect(Collectors.toList());
         } else {
-            return fixProducts(getSearchResultsSet().getProductListItems());
+            return getSearchResultsSet().getProductListItems();
         }
     }
 
@@ -246,47 +241,5 @@ public class ProductListImpl extends ProductCollectionImpl implements ProductLis
     @Override
     public String getCanonicalUrl() {
         return canonicalUrl;
-    }
-
-    // TODO: This a temporary fix to solve an issue caused by SlingModel caching
-    private Collection<ProductListItem> fixedProducts;
-
-    private Collection<ProductListItem> fixProducts(Collection<ProductListItem> products) {
-        if (fixedProducts != null) {
-            return fixedProducts;
-        } else if (CollectionUtils.isEmpty(products)) {
-            fixedProducts = Collections.emptyList();
-            return fixedProducts;
-        }
-
-        resource = request.getResource();
-
-        fixedProducts = new ArrayList<>();
-        for (ProductListItem product : products) {
-            ProductListItem productListItem = new ProductListItemImpl(product.getSKU(),
-                product.getSlug(),
-                product.getTitle(),
-                product.getPriceRange(),
-                product.getImageURL(),
-                productPage,
-                null, // search results aren't targeting specific variant
-                request,
-                urlProvider,
-                this.getId());
-            fixedProducts.add(productListItem);
-        }
-        return fixedProducts;
-    }
-
-    @Override
-    protected String generateId() {
-        resource = request.getResource();
-        return super.generateId();
-    }
-
-    @Override
-    protected ComponentData getComponentData() {
-        resource = request.getResource();
-        return super.getComponentData();
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/productlist/ProductList.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/productlist/ProductList.java
@@ -19,8 +19,9 @@ import javax.annotation.Nullable;
 import com.adobe.cq.commerce.core.components.models.page.PageMetadata;
 import com.adobe.cq.commerce.core.components.models.productcollection.ProductCollection;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractCategoryRetriever;
+import com.adobe.cq.wcm.core.components.models.Component;
 
-public interface ProductList extends ProductCollection, PageMetadata {
+public interface ProductList extends Component, ProductCollection, PageMetadata {
 
     /**
      * Name of the boolean resource property indicating if the product list should render the category title.

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/productlist/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/productlist/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("3.0.0")
+@Version("3.1.0")
 package com.adobe.cq.commerce.core.components.models.productlist;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
+++ b/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
@@ -53,6 +53,10 @@
                     "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
                     "startLevel": "3",
                     "structureDepth": "2"
+                  },
+                  "product": {
+                    "sling:resourceType": "venia/components/commerce/product",
+                    "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
                   }
                 }
               }
@@ -70,7 +74,11 @@
                       "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
                       "startLevel": "3",
                       "structureDepth": "2"
-                    }
+                    },
+	                "product": {
+	                  "sling:resourceType": "venia/components/commerce/product",
+	                  "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
+	                }
                   }
                 }
               }
@@ -88,6 +96,10 @@
                     "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
                     "startLevel": "3",
                     "structureDepth": "2"
+                  },
+                  "productlist": {
+                    "sling:resourceType": "venia/components/commerce/productlist",
+                    "sling:resourceSuperType": "core/cif/components/commerce/productlist/v1/productlist"
                   }
                 }
               }
@@ -105,6 +117,10 @@
                       "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
                       "startLevel": "3",
                       "structureDepth": "2"
+                    },
+                    "productlist": {
+                      "sling:resourceType": "venia/components/commerce/productlist",
+                      "sling:resourceSuperType": "core/cif/components/commerce/productlist/v1/productlist"
                     }
                   }
                 }
@@ -168,7 +184,15 @@
                         "jcr:primaryType": "cq:Page",
                         "jcr:content": {
                           "jcr:primaryType": "cq:PageContent",
-                          "sling:resourceType": "venia/components/page"
+                          "sling:resourceType": "venia/components/page",
+                          "root": {
+			                "responsivegrid": {
+			                  "product": {
+			                    "sling:resourceType": "venia/components/commerce/product",
+			                    "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
+			                  }
+			                }
+			              }
                         },
                         "product-specific-page": {
                           "jcr:primaryType": "cq:Page",
@@ -192,7 +216,16 @@
                       "category-page": {
                         "jcr:primaryType": "cq:Page",
                         "jcr:content": {
-                          "jcr:primaryType": "cq:PageContent"
+                          "jcr:primaryType": "cq:PageContent",
+                          "sling:resourceType": "venia/components/page",
+                          "root": {
+			                "responsivegrid": {
+			                  "product": {
+			                    "sling:resourceType": "venia/components/commerce/productlist",
+			                    "sling:resourceSuperType": "core/cif/components/commerce/productlist/v1/productlist"
+			                  }
+			                }
+			              }
                         }
                       }
                     }

--- a/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
+++ b/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
@@ -57,7 +57,7 @@
                   "product": {
                     "sling:resourceType": "venia/components/commerce/product",
                     "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
-                  }
+                  }  
                 }
               }
             },
@@ -75,10 +75,10 @@
                       "startLevel": "3",
                       "structureDepth": "2"
                     },
-	                "product": {
-	                  "sling:resourceType": "venia/components/commerce/product",
-	                  "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
-	                }
+                    "product": {
+                      "sling:resourceType": "venia/components/commerce/product",
+                      "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
+                    }
                   }
                 }
               }
@@ -138,10 +138,10 @@
             "sling:resourceType": "venia/components/page",
             "root": {
               "responsivegrid": {
-                  "breadcrumb": {
-                    "sling:resourceType": "venia/components/commerce/breadcrumb",
-                    "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
-                    "startLevel": "3"
+                "breadcrumb": {
+                  "sling:resourceType": "venia/components/commerce/breadcrumb",
+                  "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
+                  "startLevel": "3"
                 }
               }
             }
@@ -186,13 +186,13 @@
                           "jcr:primaryType": "cq:PageContent",
                           "sling:resourceType": "venia/components/page",
                           "root": {
-			                "responsivegrid": {
-			                  "product": {
-			                    "sling:resourceType": "venia/components/commerce/product",
-			                    "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
-			                  }
-			                }
-			              }
+                            "responsivegrid": {
+                              "product": {
+                                "sling:resourceType": "venia/components/commerce/product",
+                                "sling:resourceSuperType": "core/cif/components/commerce/product/v1/product"
+                              }
+                            }
+                          }
                         },
                         "product-specific-page": {
                           "jcr:primaryType": "cq:Page",
@@ -219,13 +219,13 @@
                           "jcr:primaryType": "cq:PageContent",
                           "sling:resourceType": "venia/components/page",
                           "root": {
-			                "responsivegrid": {
-			                  "product": {
-			                    "sling:resourceType": "venia/components/commerce/productlist",
-			                    "sling:resourceSuperType": "core/cif/components/commerce/productlist/v1/productlist"
-			                  }
-			                }
-			              }
+                            "responsivegrid": {
+                              "product": {
+                                "sling:resourceType": "venia/components/commerce/productlist",
+                                "sling:resourceSuperType": "core/cif/components/commerce/productlist/v1/productlist"
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/components/page/head.html
+++ b/examples/ui.apps/src/main/content/jcr_root/apps/cif-components-examples/components/page/head.html
@@ -1,0 +1,41 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ 
+  ~ Copyright 2019 Adobe. All rights reserved.
+  ~ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License. You may obtain a copy
+  ~ of the License at http://www.apache.org/licenses/LICENSE-2.0
+  ~ 
+  ~ Unless required by applicable law or agreed to in writing, software distributed under
+  ~ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  ~ OF ANY KIND, either express or implied. See the License for the specific language
+  ~ governing permissions and limitations under the License.
+  ~ 
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<template
+    data-sly-template.head="${ @ page }"
+    data-sly-use.headlibRenderer="headlibs.html"
+    data-sly-use.headResources="head.resources.html"
+    data-sly-use.metadata="com.adobe.cq.commerce.core.components.models.page.PageMetadata"
+>
+    <meta charset="UTF-8" />
+    <title>${metadata.metaTitle}</title>
+    <meta data-sly-test.keywords="${metadata.metaKeywords}" name="keywords" content="${keywords}" />
+    <meta data-sly-test.description="${metadata.metaDescription}" name="description" content="${description}" />
+    <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link data-sly-test.canonical="${metadata.canonicalUrl}" rel="canonical" href="${canonical}" />
+
+    <sly data-sly-include="customheaderlibs.html"></sly>
+    <sly
+        data-sly-call="${headlibRenderer.headlibs @
+                                designPath                = page.designPath,
+                                staticDesignPath          = page.staticDesignPath,
+                                clientLibCategories       = page.clientLibCategories,
+                                clientLibCategoriesJsHead = page.clientLibCategoriesJsHead,
+                                hasCloudconfigSupport     = page.hasCloudconfigSupport}"
+    ></sly>
+    <sly
+        data-sly-test.appResourcesPath="${page.appResourcesPath}"
+        data-sly-call="${headResources.favicons @ path = appResourcesPath}"
+    ></sly>
+</template>

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/CommerceTestBase.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/CommerceTestBase.java
@@ -14,12 +14,15 @@
 
 package com.adobe.cq.commerce.it.http;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
 import org.apache.sling.testing.clients.osgi.OsgiConsoleClient;
@@ -37,6 +40,7 @@ import com.adobe.cq.testing.client.CQClient;
 import com.adobe.cq.testing.client.CommerceClient;
 import com.adobe.cq.testing.junit.rules.CQAuthorClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.apache.http.HttpStatus.SC_MOVED_TEMPORARILY;
 
@@ -51,6 +55,8 @@ public class CommerceTestBase {
     protected static final String CMP_EXAMPLES_DEMO_SELECTOR = ".cmp-examples-demo__top";
 
     private static final String CONFIGURATION_CONSOLE_URL = "/system/console/configMgr";
+
+    protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @ClassRule
     public static final CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
@@ -160,5 +166,9 @@ public class CommerceTestBase {
 
         // Wait a bit more so that other bundles can restart
         Thread.sleep(2000);
+    }
+
+    protected static String getResource(String filename) throws IOException {
+        return IOUtils.toString(CommerceTestBase.class.getClassLoader().getResourceAsStream(filename), StandardCharsets.UTF_8);
     }
 }

--- a/it/http/src/test/resources/datalayer/chaz-kangeroo-hoodie-product.json
+++ b/it/http/src/test/resources/datalayer/chaz-kangeroo-hoodie-product.json
@@ -1,0 +1,43 @@
+{
+  "product-500741b9f1": {
+    "xdm:SKU": "MH01",
+    "xdm:listPrice": 52.0,
+    "xdm:assets": [
+      {
+        "repo:path": "/content/dam/core-components-examples/library/cif-sample-assets/catalog/product/chaz-kangeroo-hoodie/mh01-gray_main_2.jpg",
+        "xdm:tags": [],
+        "repo:id": "image-1b75bd4564",
+        "@type": "image"
+      },
+      {
+        "repo:path": "/content/dam/core-components-examples/library/cif-sample-assets/catalog/product/chaz-kangeroo-hoodie/mh01-gray_alt1_2.jpg",
+        "xdm:tags": [],
+        "repo:id": "image-72c282d214",
+        "@type": "image"
+      },
+      {
+        "repo:path": "/content/dam/core-components-examples/library/cif-sample-assets/catalog/product/chaz-kangeroo-hoodie/mh01-gray_back_2.jpg",
+        "xdm:tags": [],
+        "repo:id": "image-b01e75ba46",
+        "@type": "image"
+      }
+    ],
+    "xdm:currencyCode": "USD",
+    "xdm:categories": [
+      {
+        "repo:id": "category-4a44dc1536",
+        "xdm:name": "category-1",
+        "xdm:asset": {
+          "repo:path": "/url/to/image",
+          "xdm:tags": [],
+          "repo:id": "image-5e4329fc2c",
+          "@type": "image"
+        }
+      }
+    ],
+    "repo:modifyDate": "2019-05-21T15:59:35Z",
+    "dc:description": "<p>Ideal for cold-weather training or work outdoors, the Chaz Hoodie promises superior warmth with every wear. Thick material blocks out the wind as ribbed cuffs and bottom band seal in body heat.</p>\n<p>• Two-tone gray heather hoodie.<br />• Drawstring-adjustable hood. <br />• Machine wash/dry.</p>",
+    "@type": "cif-components-examples/components/product",
+    "dc:title": "Chaz Kangeroo Hoodie"
+  }
+}

--- a/it/http/src/test/resources/datalayer/outdoor-productlist-items.json
+++ b/it/http/src/test/resources/datalayer/outdoor-productlist-items.json
@@ -1,0 +1,56 @@
+[
+  {
+    "productlist-4834971259-item-d8f7aa6253": {
+      "xdm:SKU": "24-MB02",
+      "xdm:listPrice": 59.0,
+      "xdm:currencyCode": "USD",
+      "@type": "core/cif/components/commerce/productlistitem",
+      "dc:title": "Fusion Backpack"
+    }
+  },
+  {
+    "productlist-4834971259-item-746a9ae1b7": {
+      "xdm:SKU": "24-MG03",
+      "xdm:listPrice": 54.0,
+      "xdm:currencyCode": "USD",
+      "@type": "core/cif/components/commerce/productlistitem",
+      "dc:title": "Summit Watch"
+    }
+  },
+  {
+    "productlist-4834971259-item-e38fb02cec": {
+      "xdm:SKU": "24-WG01",
+      "xdm:listPrice": 49.0,
+      "xdm:currencyCode": "USD",
+      "@type": "core/cif/components/commerce/productlistitem",
+      "dc:title": "Bolo Sport Watch"
+    }
+  },
+  {
+    "productlist-4834971259-item-500741b9f1": {
+      "xdm:SKU": "MH01",
+      "xdm:listPrice": 52.0,
+      "xdm:currencyCode": "USD",
+      "@type": "core/cif/components/commerce/productlistitem",
+      "dc:title": "Chaz Kangeroo Hoodie"
+    }
+  },
+  {
+    "productlist-4834971259-item-9bd673acd2": {
+      "xdm:SKU": "MH03",
+      "xdm:listPrice": 63.0,
+      "xdm:currencyCode": "USD",
+      "@type": "core/cif/components/commerce/productlistitem",
+      "dc:title": "Bruno Compete Hoodie"
+    }
+  },
+  {
+    "productlist-4834971259-item-bb9507166d": {
+      "xdm:SKU": "WJ04",
+      "xdm:listPrice": 84.0,
+      "xdm:currencyCode": "USD",
+      "@type": "core/cif/components/commerce/productlistitem",
+      "dc:title": "Ingrid Running Jacket"
+    }
+  }
+]

--- a/it/http/src/test/resources/datalayer/outdoor-productlist.json
+++ b/it/http/src/test/resources/datalayer/outdoor-productlist.json
@@ -1,0 +1,6 @@
+{
+  "productlist-4834971259": {
+    "repo:modifyDate": "2020-05-19T13:15:43Z",
+    "@type": "cif-components-examples/components/productlist"
+  }
+}


### PR DESCRIPTION
This PR solves a bug related to Sling model caching: it now ensures that the right `product` or `productlist` resource is used when adapting to the `Product` or `ProductList` component. The change is pretty small, most of the changes relate to unit and integration tests.

## How Has This Been Tested?

Enabled Sling model caching in unit tests (by using the right maven dependency), and also enabled the use of the `PageMetadata` component on the pages of the CIF components library, so we can test Sling model caching and also the datalayer data to make sure this works as expected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
