### PR TITLE
CIF-1920 - Move XFPage dialog extensions to CIF core components

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/XFDialogExtensionsRenderConditionServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/XFDialogExtensionsRenderConditionServlet.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ *    Copyright 2021 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.core.components.internal.servlets;
+
+import java.util.Arrays;
+
+import javax.servlet.Servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+import com.adobe.granite.ui.components.rendercondition.RenderCondition;
+import com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition;
+
+@Component(
+    service = Servlet.class,
+    name = "XFDialogExtensionsRenderConditionServlet",
+    immediate = true,
+    property = {
+        "sling.servlet.resourceTypes=core/cif/components/renderconditions/xf-extensions",
+        "sling.servlet.methods=GET",
+        "sling.servlet.extensions=html"
+    })
+public class XFDialogExtensionsRenderConditionServlet extends SlingSafeMethodsServlet {
+
+    private static final String ADDON_BUNDLE = "com.adobe.cq.cif.commerce-addon-bundle";
+
+    private BundleContext bundleContext;
+
+    @Activate
+    protected void activate(ComponentContext ctx) {
+        bundleContext = ctx.getBundleContext();
+    }
+
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) {
+        Bundle[] bundles = bundleContext.getBundles();
+        boolean enable = Arrays.asList(bundles).stream().anyMatch(b -> ADDON_BUNDLE.equals(b.getSymbolicName()));
+        request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(enable));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/XFDialogExtensionsRenderConditionServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/XFDialogExtensionsRenderConditionServletTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ *
+ *    Copyright 2021 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.core.components.internal.servlets;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+
+import com.adobe.granite.ui.components.rendercondition.RenderCondition;
+import com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition;
+
+public class XFDialogExtensionsRenderConditionServletTest {
+
+    private MockSlingHttpServletRequest request;
+    private XFDialogExtensionsRenderConditionServlet servlet;
+    private ComponentContext ctx;
+    private BundleContext bundleContext;
+    private Bundle bundle;
+
+    @Before
+    public void setUp() {
+        ctx = Mockito.mock(ComponentContext.class);
+        bundleContext = Mockito.mock(BundleContext.class);
+        bundle = Mockito.mock(Bundle.class);
+
+        Mockito.when(ctx.getBundleContext()).thenReturn(bundleContext);
+        Mockito.when(bundleContext.getBundles()).thenReturn(ArrayUtils.toArray(bundle));
+
+        request = new MockSlingHttpServletRequest(null);
+        servlet = new XFDialogExtensionsRenderConditionServlet();
+        servlet.activate(ctx);
+    }
+
+    @Test
+    public void testAddOnBundleFound() {
+        Mockito.when(bundle.getSymbolicName()).thenReturn("com.adobe.cq.cif.commerce-addon-bundle");
+
+        servlet.doGet(request, null);
+
+        SimpleRenderCondition condition = (SimpleRenderCondition) request.getAttribute(RenderCondition.class.getName());
+        Assert.assertTrue(condition.check());
+    }
+
+    @Test
+    public void testAddOnBundleNotFound() {
+        Mockito.when(bundle.getSymbolicName()).thenReturn("com.adobe.cq.cif.not-found");
+
+        servlet.doGet(request, null);
+
+        SimpleRenderCondition condition = (SimpleRenderCondition) request.getAttribute(RenderCondition.class.getName());
+        Assert.assertFalse(condition.check());
+    }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="CIF Experience Fragment Page"
+    sling:resourceSuperType="cq/experience-fragments/components/xfpage"
+    componentGroup=".hidden"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
@@ -1,15 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured">
-    <content jcr:primaryType="nt:unstructured">
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Experience Fragment"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[cq.common.wcm,core.wcm.page.properties,cq.wcm.msm.properties,cq.siteadmin.admin.properties,cq.experience-fragments.properties.tabs,cq.experience-fragments.target.properties]"
+    mode="edit">
+    <content
+        granite:class="cq-dialog-content-page"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
         <items jcr:primaryType="nt:unstructured">
-            <tabs jcr:primaryType="nt:unstructured">
+            <tabs
+                granite:class="cq-siteadmin-admin-properties-tabs"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                size="L">
                 <items jcr:primaryType="nt:unstructured">
-                    <commerce jcr:primaryType="nt:unstructured">
+                    <commerce
+                        cq:showOnCreate="{Boolean}true"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Commerce"
+                        sling:orderBefore="cloudservices"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
                         <items jcr:primaryType="nt:unstructured">
-                            <column jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
-                                    <pagesSection jcr:primaryType="nt:unstructured"/>
+                                    <pagesSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Commerce Pages"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <productPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to CIF product page."
+                                                fieldLabel="Product Page"
+                                                name="./cq:cifProductPage"
+                                                rootPath="/content"/>
+                                            <categoryPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to CIF category page."
+                                                fieldLabel="Category Page"
+                                                name="./cq:cifCategoryPage"
+                                                rootPath="/content"/>
+                                            <searchResultsPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to search results page."
+                                                fieldLabel="Search Results Page"
+                                                name="./cq:cifSearchResultsPage"
+                                                rootPath="/content"/>
+                                            <addressBookPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to address book page."
+                                                fieldLabel="Address Book Page"
+                                                name="./cq:cifAddressBookPage"
+                                                rootPath="/content"/>
+                                            <myAccountPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to my account page."
+                                                fieldLabel="My Account Page"
+                                                name="./cq:cifMyAccountPage"
+                                                rootPath="/content"/>
+                                        </items>
+                                    </pagesSection>
                                     <productsPickerSection
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Product selection"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured">
+    <content jcr:primaryType="nt:unstructured">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs jcr:primaryType="nt:unstructured">
+                <items jcr:primaryType="nt:unstructured">
+                    <commerce jcr:primaryType="nt:unstructured">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column jcr:primaryType="nt:unstructured">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <pagesSection jcr:primaryType="nt:unstructured"/>
+                                    <productsPickerSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Product selection"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <granite:rendercondition
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="core/cif/components/renderconditions/xf-extensions"/>
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <products
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/cifproductfield"
+                                                fieldDescription="Select the products associated with this experience fragment variation."
+                                                fieldLabel="Product SKUs."
+                                                filter="folderOrProductOrVariant"
+                                                multiple="true"
+                                                name="./cq:products"
+                                                rootPath="/var/commerce/products"
+                                                selectionId="combinedSku">
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    metaType="text"/>
+                                            </products>
+                                            <productstab
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/productreferencetab"
+                                                targetProperty="jcr:content/cq:products"/>
+                                        </items>
+                                    </productsPickerSection>
+                                    <categoriesPickerSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Category selection"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <granite:rendercondition
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="core/cif/components/renderconditions/xf-extensions"/>
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <categories
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/cifcategoryfield"
+                                                fieldDescription="Select the categories associated with this experience fragment variation."
+                                                fieldLabel="Category IDs."
+                                                multiple="{Boolean}true"
+                                                name="./cq:categories"
+                                                selectionId="id">
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    metaType="text"/>
+                                            </categories>
+                                            <categoriestab
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/categoryreferencetab"
+                                                targetProperty="jcr:content/cq:categories"/>
+                                        </items>
+                                    </categoriesPickerSection>
+                                    <fragmentLocationSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Catalog placeholder location"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <granite:rendercondition
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="core/cif/components/renderconditions/xf-extensions"/>
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <fragmentLocation
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="This must match the location defined on pages with the commerce experience fragment component."
+                                                fieldLabel="The location of the experience fragment (can be empty)."
+                                                name="./fragmentLocation"/>
+                                        </items>
+                                    </fragmentLocationSection>
+                                </items>
+                            </column>
+                        </items>
+                    </commerce>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>


### PR DESCRIPTION
- create xfpage cif component with XF dialog extensions
- create rendercondition servlet to only display the dialog extension with the CIF Add-On bundle

This PR moves the entire `xfpage` dialog from the AEM Archetype + Venia to the CIF components in a new `xfpage` component extending `cq/experience-fragments/components/xfpage`. This way we can easily modify and push updates to customers.

In addition, we only want to display some dialog extensions when the CIF Add-On is present, so I added a new `rendercondition` that detects if the CIF Add-On bundle is available.

The corresponding Venia PR to remove the old dialogs is https://github.com/adobe/aem-cif-guides-venia/pull/114

Note that the dialog overlay added in this PR corresponds to what was until now added in the AEM archetype and needs to be removed at https://github.com/adobe/aem-project-archetype/blob/master/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/_cq_dialog/.content.xml

## How Has This Been Tested?

Added unit tests and UI tests in the corresponding Venia PR

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
