### PR TITLE
CIF-1785 - Implement ComponentExporter for category carousel component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/categorylist/FeaturedCategoryListImpl.java
@@ -240,6 +240,6 @@ public class FeaturedCategoryListImpl extends DataLayerComponent implements Feat
 
     @Override
     public String getExportedType() {
-        return RESOURCE_TYPE;
+        return resource.getResourceType();
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
@@ -214,9 +214,8 @@ public class ProductCarouselImpl extends DataLayerComponent implements ProductCa
             return Collections.emptyList();
         }
         return baseProductSkus.stream().map(sku -> new ProductListItemImpl(
-            CommerceIdentifierImpl.fromProductSku(sku), "", productPage))
+            CommerceIdentifierImpl.fromProductSku(sku), getId(), productPage))
             .collect(Collectors.toList());
-
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselImpl.java
@@ -220,6 +220,6 @@ public class ProductCarouselImpl extends DataLayerComponent implements ProductCa
 
     @Override
     public String getExportedType() {
-        return RESOURCE_TYPE;
+        return resource.getResourceType();
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
@@ -241,7 +241,7 @@ public class ProductTeaserImpl extends DataLayerComponent implements ProductTeas
 
     @Override
     public String getExportedType() {
-        return RESOURCE_TYPE;
+        return resource.getResourceType();
     }
 
     // DataLayer methods

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsImpl.java
@@ -52,6 +52,7 @@ import com.adobe.cq.commerce.core.components.services.UrlProvider;
 import com.adobe.cq.commerce.core.components.services.UrlProvider.ProductIdentifierType;
 import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
+import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
@@ -59,7 +60,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Model(
     adaptables = SlingHttpServletRequest.class,
-    adapters = ProductCarousel.class,
+    adapters = { ProductCarousel.class, ComponentExporter.class },
     resourceType = RelatedProductsImpl.RESOURCE_TYPE)
 @Exporter(
     name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsImpl.java
@@ -188,7 +188,7 @@ public class RelatedProductsImpl extends DataLayerComponent implements ProductCa
 
     @Override
     public String getExportedType() {
-        return RESOURCE_TYPE;
+        return resource.getResourceType();
     }
 
     public RelationType getRelationType() {

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserImpl.java
@@ -215,7 +215,7 @@ public class CommerceTeaserImpl implements CommerceTeaser {
 
     @Override
     public String getExportedType() {
-        return RESOURCE_TYPE;
+        return resource.getResourceType();
     }
 
     @Override

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsImplTest.java
@@ -158,12 +158,6 @@ public class RelatedProductsImplTest {
     }
 
     @Test
-    public void testNoProductIdentifiersYet() throws Exception {
-        setUp(RelationType.RELATED_PRODUCTS, "graphql/magento-graphql-relatedproducts-result.json", false);
-        Assert.assertEquals(0, relatedProducts.getProductIdentifiers().size());
-    }
-
-    @Test
     public void testRelatedProductsWithoutRelationType() throws Exception {
         setUp(null, "graphql/magento-graphql-relatedproducts-result.json", false);
         assertProducts();
@@ -212,6 +206,18 @@ public class RelatedProductsImplTest {
 
         String expectedQuery = "{products(filter:{sku:{eq:\"24-MG01\"}}){items{__typename,related_products{__typename,sku,name,thumbnail{label,url},url_key,price_range{minimum_price{regular_price{value,currency},final_price{value,currency},discount{amount_off,percent_off}}},... on ConfigurableProduct{price_range{maximum_price{regular_price{value,currency},final_price{value,currency},discount{amount_off,percent_off}}}},... on ConfigurableProduct{variants{product{sku}}},description{html}}}}}";
         Assert.assertEquals(expectedQuery, captor.getValue());
+    }
+
+    @Test
+    public void testJsonExportForRelatedProducts() throws Exception {
+        setUp(RelationType.RELATED_PRODUCTS, "graphql/magento-graphql-relatedproducts-result.json", false);
+        Utils.testJSONExport(relatedProducts, "/exporter/related-products.json");
+    }
+
+    @Test
+    public void testJsonExportForUpsellProducts() throws Exception {
+        setUp(RelationType.UPSELL_PRODUCTS, "graphql/magento-graphql-upsellproducts-result.json", true);
+        Utils.testJSONExport(relatedProducts, "/exporter/upsell-products.json");
     }
 
     private void assertProducts() {

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/teaser/CommerceTeaserImplTest.java
@@ -132,7 +132,7 @@ public class CommerceTeaserImplTest {
         Assert.assertEquals("The id is correct", "id", commerceTeaser.getId());
         Assert.assertNull("The link URL is null", commerceTeaser.getLinkURL());
         Assert.assertNull(commerceTeaser.getData());
-        Assert.assertEquals("The exported resource type is correct", "core/cif/components/content/teaser/v1/teaser",
+        Assert.assertEquals("The exported resource type is correct", "venia/components/content/teaser",
             commerceTeaser.getExportedType());
     }
 

--- a/bundles/core/src/test/resources/exporter/commerce-teaser.json
+++ b/bundles/core/src/test/resources/exporter/commerce-teaser.json
@@ -43,5 +43,5 @@
   "actionsEnabled": true,
   "imageLinkHidden": false,
   "titleLinkHidden": false,
-  ":type": "core/cif/components/content/teaser/v1/teaser"
+  ":type": "venia/components/content/teaser"
 }

--- a/bundles/core/src/test/resources/exporter/featuredcategories.json
+++ b/bundles/core/src/test/resources/exporter/featuredcategories.json
@@ -2,7 +2,7 @@
   "id": "featuredcategorylist-4295dd6c7a",
   "configured": true,
   "titleType": "h2",
-  ":type": "core/cif/components/commerce/featuredcategorylist/v1/featuredcategorylist",
+  ":type": "venia/components/commerce/featuredcategorylist",
   "categoryItems": [
     {
       "assetPath": null,

--- a/bundles/core/src/test/resources/exporter/productcarousel.json
+++ b/bundles/core/src/test/resources/exporter/productcarousel.json
@@ -44,5 +44,5 @@
     }
   ],
   "titleType": "h2",
-  ":type": "core/cif/components/commerce/productcarousel/v1/productcarousel"
+  ":type": "venia/components/commerce/productcarousel"
 }

--- a/bundles/core/src/test/resources/exporter/productcarousel.json
+++ b/bundles/core/src/test/resources/exporter/productcarousel.json
@@ -3,7 +3,7 @@
   "configured": true,
   "productIdentifiers": [
     {
-      "id": "-item-f70dc07ce5",
+      "id": "productcarousel-15914e2010-item-f70dc07ce5",
       "commerceIdentifier": {
         "entityType": "PRODUCT",
         "value": "NOT-FOUND",
@@ -11,7 +11,7 @@
       }
     },
     {
-      "id": "-item-62ea014ced",
+      "id": "productcarousel-15914e2010-item-62ea014ced",
       "commerceIdentifier": {
         "entityType": "PRODUCT",
         "value": "24-MG01",
@@ -19,7 +19,7 @@
       }
     },
     {
-      "id": "-item-8309e8957e",
+      "id": "productcarousel-15914e2010-item-8309e8957e",
       "commerceIdentifier": {
         "entityType": "PRODUCT",
         "value": "MJ01",
@@ -27,7 +27,7 @@
       }
     },
     {
-      "id": "-item-05eb031653",
+      "id": "productcarousel-15914e2010-item-05eb031653",
       "commerceIdentifier": {
         "entityType": "PRODUCT",
         "value": "faultyproduct",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "id": "-item-edd18cf4f6",
+      "id": "productcarousel-15914e2010-item-edd18cf4f6",
       "commerceIdentifier": {
         "entityType": "PRODUCT",
         "value": "WJ01",

--- a/bundles/core/src/test/resources/exporter/productteaser-full.json
+++ b/bundles/core/src/test/resources/exporter/productteaser-full.json
@@ -9,7 +9,7 @@
         "value": "MJ01",
         "type": "SKU"
     },
-    ":type": "core/cif/components/commerce/productteaser/v1/productteaser",
+    ":type": "venia/components/commerce/productteaser",
     "dataLayer": {
         "productteaser-b968fab190": {
             "xdm:SKU": "MJ01",

--- a/bundles/core/src/test/resources/exporter/productteaser-nosku.json
+++ b/bundles/core/src/test/resources/exporter/productteaser-nosku.json
@@ -1,7 +1,7 @@
 {
     "id": "productteaser-4571ccb4df",
     "virtualProduct": false,
-    ":type": "core/cif/components/commerce/productteaser/v1/productteaser",
+    ":type": "venia/components/commerce/productteaser",
     "dataLayer": {
         "productteaser-4571ccb4df": {
             "@type": "venia/components/commerce/productteaser"

--- a/bundles/core/src/test/resources/exporter/productteaser.json
+++ b/bundles/core/src/test/resources/exporter/productteaser.json
@@ -7,7 +7,7 @@
         "type": "SKU"
     },
     "name": "Beaumont Summit Kit",
-    ":type": "core/cif/components/commerce/productteaser/v1/productteaser",
+    ":type": "venia/components/commerce/productteaser",
     "dataLayer": {
         "productteaser-7ca4f665c4": {
             "xdm:SKU": "MJ01",

--- a/bundles/core/src/test/resources/exporter/related-products.json
+++ b/bundles/core/src/test/resources/exporter/related-products.json
@@ -1,0 +1,38 @@
+{
+  "id": "relatedproducts-d8575a4daf",
+  "relationType": "RELATED_PRODUCTS",
+  "configured": true,
+  "commerceIdentifier": {
+    "entityType": "PRODUCT",
+    "value": "24-MG01",
+    "type": "SKU"
+  },
+  "titleType": "h2",
+  ":type": "core/cif/components/commerce/relatedproducts/v1/relatedproducts",
+  "productIdentifiers": [
+    {
+      "id": "relatedproducts-d8575a4daf-item-9b55e5472b",
+      "commerceIdentifier": {
+        "entityType": "PRODUCT",
+        "value": "24-MB01",
+        "type": "SKU"
+      }
+    },
+    {
+      "id": "relatedproducts-d8575a4daf-item-cd8d53884f",
+      "commerceIdentifier": {
+        "entityType": "PRODUCT",
+        "value": "24-MB04",
+        "type": "SKU"
+      }
+    },
+    {
+      "id": "relatedproducts-d8575a4daf-item-c1f0eb0a23",
+      "commerceIdentifier": {
+        "entityType": "PRODUCT",
+        "value": "24-MB03",
+        "type": "SKU"
+      }
+    }
+  ]
+}

--- a/bundles/core/src/test/resources/exporter/related-products.json
+++ b/bundles/core/src/test/resources/exporter/related-products.json
@@ -8,7 +8,7 @@
     "type": "SKU"
   },
   "titleType": "h2",
-  ":type": "core/cif/components/commerce/relatedproducts/v1/relatedproducts",
+  ":type": "venia/components/commerce/relatedproducts",
   "productIdentifiers": [
     {
       "id": "relatedproducts-d8575a4daf-item-9b55e5472b",

--- a/bundles/core/src/test/resources/exporter/upsell-products.json
+++ b/bundles/core/src/test/resources/exporter/upsell-products.json
@@ -8,7 +8,7 @@
     "type": "URL_KEY"
   },
   "titleType": "h3",
-  ":type": "core/cif/components/commerce/relatedproducts/v1/relatedproducts",
+  ":type": "venia/components/commerce/relatedproducts",
   "productIdentifiers": [
     {
       "id": "relatedproducts-44ab3d0edb-item-9b55e5472b",

--- a/bundles/core/src/test/resources/exporter/upsell-products.json
+++ b/bundles/core/src/test/resources/exporter/upsell-products.json
@@ -1,0 +1,38 @@
+{
+  "id": "relatedproducts-44ab3d0edb",
+  "relationType": "UPSELL_PRODUCTS",
+  "configured": true,
+  "commerceIdentifier": {
+    "entityType": "PRODUCT",
+    "value": "endurance-watch",
+    "type": "URL_KEY"
+  },
+  "titleType": "h3",
+  ":type": "core/cif/components/commerce/relatedproducts/v1/relatedproducts",
+  "productIdentifiers": [
+    {
+      "id": "relatedproducts-44ab3d0edb-item-9b55e5472b",
+      "commerceIdentifier": {
+        "entityType": "PRODUCT",
+        "value": "24-MB01",
+        "type": "SKU"
+      }
+    },
+    {
+      "id": "relatedproducts-44ab3d0edb-item-cd8d53884f",
+      "commerceIdentifier": {
+        "entityType": "PRODUCT",
+        "value": "24-MB04",
+        "type": "SKU"
+      }
+    },
+    {
+      "id": "relatedproducts-44ab3d0edb-item-c1f0eb0a23",
+      "commerceIdentifier": {
+        "entityType": "PRODUCT",
+        "value": "24-MB03",
+        "type": "SKU"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- fixed returned resource type for json export for all components

The `categorycarousel` reuses the `FeaturedCategoryList` sling model but the model wrongly returned the "hard-coded" CIF component type. To align with what the WCM core components do, and what is done in the datalayer, I changed all components already implementing `ComponentExporter` to return the actual resource type. This "fixes" the export for the `categorycarousel` component and for all other components.

## How Has This Been Tested?

Adapted unit tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
