### PR TITLE
CIF-2075 - fix NPE from category list with empty objects

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
@@ -67,8 +67,8 @@ class GraphQLCategoryProvider {
 
         Query rootQuery = response.getData();
         List<CategoryTree> category = rootQuery.getCategoryList();
-        if (category.isEmpty()) {
-            LOGGER.warn("Magento category not found for identifier: " + categoryIdentifier);
+        if (category.isEmpty() || category.get(0) == null) {
+            LOGGER.warn("Category not found for identifier: " + categoryIdentifier);
             return Collections.emptyList();
         }
 

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
@@ -90,19 +90,24 @@ public class GraphQLCategoryProviderTest {
         MagentoGraphqlClient graphqlClient = mock(MagentoGraphqlClient.class);
         Whitebox.setInternalState(categoryProvider, "magentoGraphqlClient", graphqlClient);
 
-        // test category not found
         GraphqlResponse<Query, Error> response = mock(GraphqlResponse.class);
-        when(graphqlClient.execute(anyString())).thenReturn(response);
         Query rootQuery = mock(Query.class);
+        List<CategoryTree> list = mock(List.class);
+        CategoryTree category = mock(CategoryTree.class);
+
+        // test category not found
+        when(graphqlClient.execute(anyString())).thenReturn(response);
         when(response.getData()).thenReturn(rootQuery);
-        Assert.assertNull(rootQuery.getCategory());
+        Assert.assertTrue(categoryProvider.getChildCategories("-10", 10, false).isEmpty());
+
+        // test category found but null
+        when(rootQuery.getCategoryList()).thenReturn(list);
+        when(rootQuery.getCategoryList().get(0)).thenReturn(null);
         Assert.assertTrue(categoryProvider.getChildCategories("-10", 10, false).isEmpty());
 
         // test category children not found
-        CategoryTree category = mock(CategoryTree.class);
-        when(rootQuery.getCategory()).thenReturn(category);
+        when(rootQuery.getCategoryList().get(0)).thenReturn(category);
         when(category.getChildren()).thenReturn(null);
-        Assert.assertNull(category.getChildren());
         Assert.assertTrue(categoryProvider.getChildCategories("13", 10, false).isEmpty());
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix NPE from cases of category list containing h empty (null) objects. This should only happen in exceptional case.


## Related Issue

CIF-2075
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
