### PR TITLE
CIF-2060 - fix NPEs related to special handling for Launches

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
@@ -140,7 +140,6 @@ public class MagentoGraphqlClient {
         if (page != null && LaunchUtils.isLaunchBasedPath(page.getPath())) {
             Resource launchResource = LaunchUtils.getLaunchResource(configurationResource);
             launch = launchResource.adaptTo(Launch.class);
-            configurationResource = LaunchUtils.getTargetResource(configurationResource, null);
         }
 
         LOGGER.debug("Try to get a graphql client from the resource at {}", configurationResource.getPath());

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
@@ -30,7 +30,6 @@ import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.adobe.cq.commerce.graphql.client.HttpMethod;
-import com.adobe.cq.wcm.launches.utils.LaunchUtils;
 import com.day.cq.wcm.api.Page;
 
 @Model(
@@ -61,14 +60,8 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
     @PostConstruct
     void initModel() {
         // Get configuration from CIF Sling CA config
-        Resource pageContent = currentPage.getContentResource();
-        ComponentsConfiguration properties = null;
-        if (LaunchUtils.isLaunchBasedPath(currentPage.getPath())) {
-            properties = LaunchUtils.getTargetResource(pageContent, null).adaptTo(ComponentsConfiguration.class);
-        } else {
-            properties = pageContent.adaptTo(ComponentsConfiguration.class);
-        }
-
+        Resource configResource = currentPage.getContentResource();
+        ComponentsConfiguration properties = configResource.adaptTo(ComponentsConfiguration.class);
         storeView = properties.get(STORE_CODE_PROPERTY, "default");
         graphqlEndpoint = properties.get(GRAPHQL_ENDPOINT_PROPERTY, "/magento/graphql");
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/ComponentsConfigurationAdapterFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/ComponentsConfigurationAdapterFactory.java
@@ -24,8 +24,11 @@ import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
+import com.adobe.cq.wcm.launches.utils.LaunchUtils;
 import com.google.common.collect.ImmutableMap;
 
 @Component(
@@ -39,6 +42,7 @@ public class ComponentsConfigurationAdapterFactory implements AdapterFactory {
     protected static final String COMPONENTS_CONFIGURATION_CLASS_NAME = "com.adobe.cq.commerce.core.components.services.ComponentsConfiguration";
 
     private static final String SUBSERVICE_NAME = "cif-components-configuration";
+    private static final Logger LOG = LoggerFactory.getLogger(ComponentsConfigurationAdapterFactory.class);
 
     private static final Map<String, Object> authInfo = ImmutableMap.of(ResourceResolverFactory.SUBSERVICE, SUBSERVICE_NAME);
 
@@ -50,21 +54,42 @@ public class ComponentsConfigurationAdapterFactory implements AdapterFactory {
     @Reference
     private ResourceResolverFactory resolverFactory;
 
-    private ResourceResolver serviceResolver;
-
     @Override
     public <AdapterType> AdapterType getAdapter(Object adaptable, Class<AdapterType> type) {
         if (!(adaptable instanceof Resource)) {
             return null;
         }
         try (ResourceResolver serviceResolver = resolverFactory.getServiceResourceResolver(authInfo)) {
-            Resource res = serviceResolver.getResource(((Resource) adaptable).getPath());
-            ConfigurationBuilder cfgBuilder = res.adaptTo(ConfigurationBuilder.class);
+            String resourcePath = ((Resource) adaptable).getPath();
+            Resource resource = serviceResolver.getResource(resourcePath);
+
+            if (resource == null) {
+                LOG.debug("Service user permissions of {} are not sufficient to view resource at {}", serviceResolver.getUserID(),
+                    resourcePath);
+                return null;
+            }
+
+            if (LaunchUtils.isLaunchBasedPath(resource.getPath())) {
+                // In Launches we have to resolve the ComponentConfigurations from the production resource as there is still an issue
+                // with CA Configs not working properly in Launches in 6.5.x. Additionally, if the resource was created in the Launch
+                // it will not exist in production yet and so the returned target resource is null. Handle that by walking up the tree
+                // until we find any resource and try to get the configuration from there.
+                Resource sourceResource = resource;
+                Resource targetResource = null;
+                while (targetResource == null && sourceResource != null) {
+                    targetResource = LaunchUtils.getTargetResource(sourceResource, null);
+                    sourceResource = sourceResource.getParent();
+                }
+                if (targetResource != null) {
+                    resource = targetResource;
+                }
+            }
+
+            ConfigurationBuilder cfgBuilder = resource.adaptTo(ConfigurationBuilder.class);
             ComponentsConfiguration configuration = new ComponentsConfiguration(cfgBuilder.name(CONFIGURATION_NAME).asValueMap());
             return (AdapterType) configuration;
         } catch (LoginException e) {
             throw new RuntimeException(e);
         }
-
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/utils/SiteNavigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/utils/SiteNavigation.java
@@ -17,6 +17,7 @@ package com.adobe.cq.commerce.core.components.utils;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -269,21 +270,16 @@ public class SiteNavigation {
      * <br>
      * <code>page = SiteNavigation.toLaunchProductionPage(page);</code>
      * 
-     * @param page The page to be checked.
+     * @param givenPage The page to be checked.
      * @return The production version of the page if it is a Launch page, or the page itself.
      */
-    public static Page toLaunchProductionPage(Page page) {
-        if (page == null || page.getPath() == null) {
-            return page;
-        }
-
-        PageManager pageManager = page.getPageManager();
-        if (pageManager != null && LaunchUtils.isLaunchBasedPath(page.getPath())) {
-            Resource targetResource = LaunchUtils.getTargetResource(page.adaptTo(Resource.class), null);
-            Page targetPage = pageManager.getPage(targetResource.getPath());
-            page = targetPage != null ? targetPage : page;
-        }
-        return page;
+    public static Page toLaunchProductionPage(Page givenPage) {
+        return Optional.ofNullable(givenPage)
+            .map(page -> page.adaptTo(Resource.class))
+            .filter(resource -> LaunchUtils.isLaunchBasedPath(resource.getPath()))
+            .map(resource -> LaunchUtils.getTargetResource(resource, null))
+            .map(productionResource -> productionResource.adaptTo(Page.class))
+            .orElse(givenPage);
     }
 
     /**

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/utils/SiteNavigationTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/utils/SiteNavigationTest.java
@@ -115,4 +115,14 @@ public class SiteNavigationTest {
         Page pageNotFound = SiteNavigation.getGenericPage("cq:notfound", page);
         Assert.assertNull(pageNotFound);
     }
+
+    @Test
+    public void testNavigationWithLaunchAndNewlyCreatedContent() {
+        Page launchPage = context.pageManager().getPage("/content/launches/2020/09/14/mylaunch/content/venia/us/en/another-page");
+        Page productionPage = context.pageManager().getPage("/content/venia/us/en/another-page");
+        Assert.assertEquals(productionPage, SiteNavigation.toLaunchProductionPage(launchPage));
+
+        launchPage = context.pageManager().getPage("/content/launches/2020/09/14/mylaunch/content/venia/us/en/new-content-page");
+        Assert.assertSame(launchPage, SiteNavigation.toLaunchProductionPage(launchPage));
+    }
 }

--- a/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
+++ b/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
@@ -228,6 +228,29 @@
                           }
                         }
                       }
+                    },
+                    "another-page": {
+                      "jcr:primaryType": "cq:Page",
+                      "jcr:content": {
+                        "jcr:primaryType": "cq:PageContent",
+                        "sling:resourceType": "venia/components/page",
+                        "root": {
+                          "responsivegrid": {
+                            "breadcrumb": {
+                              "sling:resourceType": "venia/components/commerce/breadcrumb",
+                              "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
+                              "startLevel": "3"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "new-content-page": {
+                      "jcr:primaryType": "cq:Page",
+                      "jcr:content": {
+                        "jcr:primaryType": "cq:PageContent",
+                        "sling:resourceType": "venia/components/page"
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
## Description

Launches do not support context aware configurations in all supported product version right now. Because of that a fallback logic has been introduced to fallback to the production content of a Launch when accessing context aware configurations. This logic fails when the content was newly created in the Launch and so production content does not (yet) exists, causing NPEs in various places.

## Related Issue

CIF-2060
CIF-2061

## How Has This Been Tested?

- Create a Launch from an existing site (e.g. Venia sample storefront)
- In the Launch, create a new content page as child of a homepage
- Open the content page for editing => fails with a NPE
- Open the Homepage => navigation not rendered correctly, NPE

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
