### PR TITLE
CIF-2097 - Consume the configured custom HTTP headers in MagentoGraphqlClient

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/DeniedHttpHeaders.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/DeniedHttpHeaders.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2021 Adobe. All rights reserved.
+ *
+ *   This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.adobe.cq.commerce.core.components.client;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+public interface DeniedHttpHeaders {
+    /**
+     * A list of HTTP headers that cannot be overriden when configuring a list of custom HTTP headers
+     */
+    final Set<String> DENYLIST = ImmutableSet.of(org.apache.http.HttpHeaders.ACCEPT,
+        org.apache.http.HttpHeaders.ACCEPT_CHARSET,
+        org.apache.http.HttpHeaders.ACCEPT_ENCODING,
+        org.apache.http.HttpHeaders.ACCEPT_LANGUAGE,
+        org.apache.http.HttpHeaders.ACCEPT_RANGES,
+        org.apache.http.HttpHeaders.AGE,
+        org.apache.http.HttpHeaders.ALLOW,
+        org.apache.http.HttpHeaders.AUTHORIZATION,
+        org.apache.http.HttpHeaders.CACHE_CONTROL,
+        org.apache.http.HttpHeaders.CONNECTION,
+        org.apache.http.HttpHeaders.CONTENT_ENCODING,
+        org.apache.http.HttpHeaders.CONTENT_LANGUAGE,
+        org.apache.http.HttpHeaders.CONTENT_LENGTH,
+        org.apache.http.HttpHeaders.CONTENT_LOCATION,
+        org.apache.http.HttpHeaders.CONTENT_MD5,
+        org.apache.http.HttpHeaders.CONTENT_RANGE,
+        org.apache.http.HttpHeaders.CONTENT_TYPE,
+        org.apache.http.HttpHeaders.DATE,
+        org.apache.http.HttpHeaders.DAV,
+        org.apache.http.HttpHeaders.DEPTH,
+        org.apache.http.HttpHeaders.DESTINATION,
+        org.apache.http.HttpHeaders.ETAG,
+        org.apache.http.HttpHeaders.EXPECT,
+        org.apache.http.HttpHeaders.EXPIRES,
+        org.apache.http.HttpHeaders.FROM,
+        org.apache.http.HttpHeaders.HOST,
+        org.apache.http.HttpHeaders.IF,
+        org.apache.http.HttpHeaders.IF_MATCH,
+        org.apache.http.HttpHeaders.IF_MODIFIED_SINCE,
+        org.apache.http.HttpHeaders.IF_NONE_MATCH,
+        org.apache.http.HttpHeaders.IF_RANGE,
+        org.apache.http.HttpHeaders.IF_UNMODIFIED_SINCE,
+        org.apache.http.HttpHeaders.LAST_MODIFIED,
+        org.apache.http.HttpHeaders.LOCATION,
+        org.apache.http.HttpHeaders.LOCK_TOKEN,
+        org.apache.http.HttpHeaders.MAX_FORWARDS,
+        org.apache.http.HttpHeaders.OVERWRITE,
+        org.apache.http.HttpHeaders.PRAGMA,
+        org.apache.http.HttpHeaders.PROXY_AUTHENTICATE,
+        org.apache.http.HttpHeaders.PROXY_AUTHORIZATION,
+        org.apache.http.HttpHeaders.RANGE,
+        org.apache.http.HttpHeaders.REFERER,
+        org.apache.http.HttpHeaders.RETRY_AFTER,
+        org.apache.http.HttpHeaders.SERVER,
+        org.apache.http.HttpHeaders.STATUS_URI,
+        org.apache.http.HttpHeaders.TE,
+        org.apache.http.HttpHeaders.TIMEOUT,
+        org.apache.http.HttpHeaders.TRAILER,
+        org.apache.http.HttpHeaders.TRANSFER_ENCODING,
+        org.apache.http.HttpHeaders.UPGRADE,
+        org.apache.http.HttpHeaders.USER_AGENT,
+        org.apache.http.HttpHeaders.VARY,
+        org.apache.http.HttpHeaders.VIA,
+        org.apache.http.HttpHeaders.WARNING,
+        org.apache.http.HttpHeaders.WWW_AUTHENTICATE,
+        "Store",
+        "Preview-Version");
+}

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
@@ -226,11 +227,17 @@ public class MagentoGraphqlClient {
         String[] customHeaders = configuration.get("httpHeaders", String[].class);
 
         if (customHeaders != null) {
-            headers = Arrays.stream(customHeaders).map(headerConfig -> {
-                String name = headerConfig.substring(0, headerConfig.indexOf('='));
-                String value = headerConfig.substring(headerConfig.indexOf('=') + 1, headerConfig.length());
-                return new BasicHeader(name, value);
-            }).collect(Collectors.toList());
+            headers = Arrays.stream(customHeaders)
+                .map(headerConfig -> {
+                    String name = headerConfig.substring(0, headerConfig.indexOf('='));
+                    if (DeniedHttpHeaders.DENYLIST.stream().noneMatch(name::equalsIgnoreCase)) {
+                        String value = headerConfig.substring(headerConfig.indexOf('=') + 1, headerConfig.length());
+                        return new BasicHeader(name, value);
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
         }
 
         return headers;

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClient.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
@@ -71,6 +72,8 @@ public class MagentoGraphqlClient {
     private GraphqlClient graphqlClient;
 
     private RequestOptions requestOptions;
+
+    private List<Header> httpHeaders;
 
     /**
      * Instantiates and returns a new MagentoGraphqlClient.
@@ -219,6 +222,8 @@ public class MagentoGraphqlClient {
         if (!headers.isEmpty()) {
             requestOptions.withHeaders(headers);
         }
+
+        this.httpHeaders = headers;
     }
 
     private List<Header> getCustomHttpHeaders(ComponentsConfiguration configuration) {
@@ -296,6 +301,15 @@ public class MagentoGraphqlClient {
      */
     public GraphqlClientConfiguration getConfiguration() {
         return graphqlClient.getConfiguration();
+    }
+
+    /**
+     * Returns the list of custom HTTP headers used by the GraphQL client.
+     * 
+     * @return a {@link Map} with header names as keys and header values as values
+     */
+    public Map<String, String> getHttpHeaders() {
+        return httpHeaders.stream().collect(Collectors.toMap(Header::getName, Header::getValue));
     }
 
     private String readFallBackConfiguration(Resource resource, String propertyName) {

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/client/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("1.6.0")
+@Version("1.7.0")
 package com.adobe.cq.commerce.core.components.client;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
@@ -95,6 +95,7 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
         return method.toString();
     }
 
+    @Override
     public String getHttpHeaders() {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode objectNode = mapper.createObjectNode();
@@ -103,7 +104,7 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
             return mapper.writeValueAsString(objectNode);
         } catch (JsonProcessingException e) {
             LOGGER.error(e.getMessage(), e);
-            return "";
+            return "{}";
         }
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
@@ -14,9 +14,7 @@
 
 package com.adobe.cq.commerce.core.components.internal.models.v1.storeconfigexporter;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -35,6 +33,9 @@ import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
 import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.day.cq.wcm.api.Page;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @Model(
     adaptables = SlingHttpServletRequest.class,
@@ -94,9 +95,16 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
         return method.toString();
     }
 
-    public List<String> getHttpHeaders() {
-        return httpHeaders.entrySet().stream().map(entry -> new String(entry.getKey() + "=" + entry.getValue()))
-            .collect(Collectors.toList());
+    public String getHttpHeaders() {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode objectNode = mapper.createObjectNode();
+        httpHeaders.entrySet().stream().forEach(entry -> objectNode.put(entry.getKey(), entry.getValue()));
+        try {
+            return mapper.writeValueAsString(objectNode);
+        } catch (JsonProcessingException e) {
+            LOGGER.error(e.getMessage(), e);
+            return "";
+        }
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterImpl.java
@@ -14,6 +14,10 @@
 
 package com.adobe.cq.commerce.core.components.internal.models.v1.storeconfigexporter;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
@@ -56,6 +60,7 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
     private String graphqlEndpoint = "/magento/graphql";
     private HttpMethod method = HttpMethod.POST;
     private Page storeRootPage;
+    private Map<String, String> httpHeaders;
 
     @PostConstruct
     void initModel() {
@@ -70,6 +75,7 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
         if (magentoGraphqlClient != null) {
             GraphqlClientConfiguration graphqlClientConfiguration = magentoGraphqlClient.getConfiguration();
             method = graphqlClientConfiguration.httpMethod();
+            httpHeaders = magentoGraphqlClient.getHttpHeaders();
         }
     }
 
@@ -86,6 +92,11 @@ public class StoreConfigExporterImpl implements StoreConfigExporter {
     @Override
     public String getMethod() {
         return method.toString();
+    }
+
+    public List<String> getHttpHeaders() {
+        return httpHeaders.entrySet().stream().map(entry -> new String(entry.getKey() + "=" + entry.getValue()))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/StoreConfigExporter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/StoreConfigExporter.java
@@ -35,4 +35,9 @@ public interface StoreConfigExporter {
      * @return The URL of the storefront homepage
      */
     String getStoreRootUrl();
+
+    /**
+     * @return the list of custom HTTP headers configured in addition to the standard ones. This list is in JSON format.
+     */
+    String getHttpHeaders();
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/storeconfigexporter/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("2.0.0")
+@Version("3.0.0")
 package com.adobe.cq.commerce.core.components.models.storeconfigexporter;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClientTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/client/MagentoGraphqlClientTest.java
@@ -61,15 +61,6 @@ public class MagentoGraphqlClientTest {
     private static final ValueMap MOCK_CONFIGURATION = new ValueMapDecorator(ImmutableMap.of("cq:graphqlClient", "default", "magentoStore",
         "my-store"));
 
-    private static final List<Header> expectedHeaders = new ArrayList<>();
-
-    static {
-        expectedHeaders.add(new BasicHeader("Store", "my-store"));
-        expectedHeaders.add(new BasicHeader("customHeader-1", "value1"));
-        expectedHeaders.add(new BasicHeader("customHeader-2", "value2"));
-        expectedHeaders.add(new BasicHeader("customHeader-3", "=value3=3=3=3=3"));
-    }
-
     private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT = new ComponentsConfiguration(MOCK_CONFIGURATION);
 
     private static final String PAGE_A = "/content/pageA";
@@ -116,6 +107,13 @@ public class MagentoGraphqlClientTest {
 
     @Test
     public void testCustomHeaders() {
+
+        List<Header> expectedHeaders = new ArrayList<>();
+        expectedHeaders.add(new BasicHeader("Store", "my-store"));
+        expectedHeaders.add(new BasicHeader("customHeader-1", "value1"));
+        expectedHeaders.add(new BasicHeader("customHeader-2", "value2"));
+        expectedHeaders.add(new BasicHeader("customHeader-3", "=value3=3=3=3=3"));
+
         ValueMap MOCK_CONFIGURATION_CUSTOM_HEADERS = new ValueMapDecorator(ImmutableMap.of("cq:graphqlClient", "default", "magentoStore",
             "my-store", "httpHeaders", new String[] { "customHeader-1=value1", "customHeader-2=value2", "customHeader-3==value3=3=3=3=3",
                 "Authorization=099sx8x7v1" }));

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
@@ -43,7 +43,7 @@ public class StoreConfigExporterTest {
 
     private static final ValueMap MOCK_CONFIGURATION = new ValueMapDecorator(
         ImmutableMap.of("magentoGraphqlEndpoint", "/my/magento/graphql", "magentoStore", "my-magento-store", "cq:graphqlClient",
-            "my-graphql-client"));
+            "my-graphql-client", "httpHeaders", new String[] { "customHeader-1=value1", "customHeader-2=value2" }));
     private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT = new ComponentsConfiguration(MOCK_CONFIGURATION);
 
     @Rule
@@ -120,6 +120,15 @@ public class StoreConfigExporterTest {
         StoreConfigExporterImpl storeConfigExporter = context.request().adaptTo(StoreConfigExporterImpl.class);
 
         Assert.assertEquals("/content/pageB.html", storeConfigExporter.getStoreRootUrl());
+    }
+
+    @Test
+    public void testCustomHttpHeaders() {
+        String[] expectedHeaders = new String[] { "Store=my-magento-store", "customHeader-1=value1", "customHeader-2=value2" };
+        setupWithPage("/content/pageH", HttpMethod.POST);
+        StoreConfigExporterImpl storeConfigExporter = context.request().adaptTo(StoreConfigExporterImpl.class);
+        String[] actualHeaders = storeConfigExporter.getHttpHeaders().stream().sorted().toArray(String[]::new);
+        Assert.assertArrayEquals("The custom HTTP headers are correctly parsed", expectedHeaders, actualHeaders);
     }
 
     private void setupWithPage(String pagePath, HttpMethod method) {

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
@@ -14,6 +14,8 @@
 
 package com.adobe.cq.commerce.core.components.internal.models.v1.storeconfigexporter;
 
+import java.io.IOException;
+
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.scripting.SlingBindings;
@@ -31,6 +33,8 @@ import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.adobe.cq.launches.api.Launch;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.scripting.WCMBindingsConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
@@ -123,12 +127,19 @@ public class StoreConfigExporterTest {
     }
 
     @Test
-    public void testCustomHttpHeaders() {
-        String[] expectedHeaders = new String[] { "Store=my-magento-store", "customHeader-1=value1", "customHeader-2=value2" };
+    public void testCustomHttpHeaders() throws IOException {
+        // String[] expectedHeaders = new String[] { "Store=my-magento-store", "customHeader-1=value1", "customHeader-2=value2" };
+        // String expectedHeaders = new String[] { "Store=my-magento-store", "customHeader-1=value1", "customHeader-2=value2" };
         setupWithPage("/content/pageH", HttpMethod.POST);
         StoreConfigExporterImpl storeConfigExporter = context.request().adaptTo(StoreConfigExporterImpl.class);
-        String[] actualHeaders = storeConfigExporter.getHttpHeaders().stream().sorted().toArray(String[]::new);
-        Assert.assertArrayEquals("The custom HTTP headers are correctly parsed", expectedHeaders, actualHeaders);
+        // String[] actualHeaders = storeConfigExporter.getHttpHeaders().stream().sorted().toArray(String[]::new);
+        String expectedHeaders = "{\"Store\":\"my-magento-store\",\"customHeader-1\":\"value1\",\"customHeader-2\":\"value2\"}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode actualNode = mapper.readTree(storeConfigExporter.getHttpHeaders());
+        JsonNode expectedNode = mapper.readTree(expectedHeaders);
+
+        Assert.assertEquals("The custom HTTP headers are correctly parsed", expectedNode, actualNode);
     }
 
     private void setupWithPage(String pagePath, HttpMethod method) {

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/storeconfigexporter/StoreConfigExporterTest.java
@@ -128,11 +128,8 @@ public class StoreConfigExporterTest {
 
     @Test
     public void testCustomHttpHeaders() throws IOException {
-        // String[] expectedHeaders = new String[] { "Store=my-magento-store", "customHeader-1=value1", "customHeader-2=value2" };
-        // String expectedHeaders = new String[] { "Store=my-magento-store", "customHeader-1=value1", "customHeader-2=value2" };
         setupWithPage("/content/pageH", HttpMethod.POST);
         StoreConfigExporterImpl storeConfigExporter = context.request().adaptTo(StoreConfigExporterImpl.class);
-        // String[] actualHeaders = storeConfigExporter.getHttpHeaders().stream().sorted().toArray(String[]::new);
         String expectedHeaders = "{\"Store\":\"my-magento-store\",\"customHeader-1\":\"value1\",\"customHeader-2\":\"value2\"}";
 
         ObjectMapper mapper = new ObjectMapper();

--- a/react-components/src/components/App/app.js
+++ b/react-components/src/components/App/app.js
@@ -25,11 +25,11 @@ import useReferrerEvent from '../../utils/useReferrerEvent';
 import usePageEvent from '../../utils/usePageEvent';
 
 const App = props => {
-    const { graphqlEndpoint, storeView = 'default', graphqlMethod = 'POST', headers = [] } = useConfigContext();
+    const { graphqlEndpoint, storeView = 'default', graphqlMethod = 'POST', headers = {} } = useConfigContext();
     useCustomUrlEvent();
     useReferrerEvent();
     usePageEvent();
-    console.log(`using headers `, headers);
+
     const clientConfig = {
         link: from([
             graphqlAuthLink,

--- a/react-components/src/components/App/app.js
+++ b/react-components/src/components/App/app.js
@@ -25,17 +25,17 @@ import useReferrerEvent from '../../utils/useReferrerEvent';
 import usePageEvent from '../../utils/usePageEvent';
 
 const App = props => {
-    const { graphqlEndpoint, storeView = 'default', graphqlMethod = 'POST' } = useConfigContext();
+    const { graphqlEndpoint, storeView = 'default', graphqlMethod = 'POST', headers = [] } = useConfigContext();
     useCustomUrlEvent();
     useReferrerEvent();
     usePageEvent();
-
+    console.log(`using headers `, headers);
     const clientConfig = {
         link: from([
             graphqlAuthLink,
             new HttpLink({
                 uri: graphqlEndpoint,
-                headers: { Store: storeView },
+                headers: { ...headers, Store: storeView },
                 useGETForQueries: graphqlMethod === 'GET',
                 fetch: compressQueryFetch
             })

--- a/react-components/src/context/ConfigContext.js
+++ b/react-components/src/context/ConfigContext.js
@@ -25,6 +25,7 @@ const ConfigContextProvider = props => {
 ConfigContextProvider.propTypes = {
     config: PropTypes.shape({
         storeView: PropTypes.string.isRequired,
+        headers: PropTypes.object,
         graphqlEndpoint: PropTypes.string.isRequired,
         graphqlMethod: PropTypes.oneOf(['GET', 'POST']).isRequired,
         mountingPoints: PropTypes.shape({

--- a/ui.apps/package-lock.json
+++ b/ui.apps/package-lock.json
@@ -1787,7 +1787,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -2162,7 +2162,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -2278,7 +2278,7 @@
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
@@ -2329,7 +2329,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -2770,7 +2770,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -2806,7 +2806,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3018,7 +3018,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -3027,7 +3027,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -3036,7 +3036,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3059,7 +3059,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -3105,7 +3105,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -3203,7 +3203,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3537,7 +3537,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -3546,7 +3546,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -3821,7 +3821,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -3898,7 +3898,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4580,7 +4580,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -4591,7 +4591,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -4603,7 +4603,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -4620,7 +4620,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -4629,7 +4629,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -4640,7 +4640,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
@@ -5104,7 +5104,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5119,7 +5119,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5959,7 +5959,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -6056,7 +6056,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -6065,7 +6065,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -6074,7 +6074,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -6148,7 +6148,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6182,7 +6182,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -6227,7 +6227,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -6255,7 +6255,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -6378,7 +6378,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -6589,7 +6589,7 @@
         },
         "is-wsl": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/is-wsl/-/is-wsl-1.1.0.tgz",
           "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
           "dev": true
         },
@@ -6743,7 +6743,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -167,7 +167,12 @@ class CommerceGraphqlApi {
 (function() {
     function onDocumentReady() {
         const { storeView, graphqlEndpoint, graphqlMethod, httpHeaders } = document.querySelector('body').dataset;
-        window.CIF.CommerceGraphqlApi = new CommerceGraphqlApi({ endpoint: graphqlEndpoint, storeView, graphqlMethod, headers: JSON.parse(httpHeaders) });
+        window.CIF.CommerceGraphqlApi = new CommerceGraphqlApi({
+            endpoint: graphqlEndpoint,
+            storeView,
+            graphqlMethod,
+            headers: JSON.parse(httpHeaders)
+        });
     }
 
     if (document.readyState !== 'loading') {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -25,6 +25,7 @@ class CommerceGraphqlApi {
         this.endpoint = props.endpoint;
         this.storeView = props.storeView;
         this.method = props.graphqlMethod;
+        this.headers = props.headers;
     }
 
     async _fetch(url, params) {
@@ -47,6 +48,7 @@ class CommerceGraphqlApi {
         let params = {
             method: this.method === 'GET' && !ignoreCache ? 'GET' : 'POST',
             headers: {
+                ...this.headers,
                 'Content-Type': 'application/json',
                 Store: this.storeView
             }
@@ -164,8 +166,8 @@ class CommerceGraphqlApi {
 
 (function() {
     function onDocumentReady() {
-        const { storeView, graphqlEndpoint, graphqlMethod } = document.querySelector('body').dataset;
-        window.CIF.CommerceGraphqlApi = new CommerceGraphqlApi({ endpoint: graphqlEndpoint, storeView, graphqlMethod });
+        const { storeView, graphqlEndpoint, graphqlMethod, httpHeaders } = document.querySelector('body').dataset;
+        window.CIF.CommerceGraphqlApi = new CommerceGraphqlApi({ endpoint: graphqlEndpoint, storeView, graphqlMethod, headers: JSON.parse(httpHeaders) });
     }
 
     if (document.readyState !== 'loading') {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/page.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/page.html
@@ -1,15 +1,15 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ 
+  ~
   ~ Copyright 2019 Adobe. All rights reserved.
   ~ This file is licensed to you under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License. You may obtain a copy
   ~ of the License at http://www.apache.org/licenses/LICENSE-2.0
-  ~ 
+  ~
   ~ Unless required by applicable law or agreed to in writing, software distributed under
   ~ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
   ~ OF ANY KIND, either express or implied. See the License for the specific language
   ~ governing permissions and limitations under the License.
-  ~ 
+  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <!DOCTYPE html>
 <html
@@ -21,14 +21,15 @@
     data-sly-use.redirect="redirect.html"
 >
     <head data-sly-call="${head.head @ page = page}"></head>
-    <body 
+    <body
         id="${page.id}"
-        class="${page.cssClassNames}" 
-        data-store-view="${storeView.storeView}" 
+        class="${page.cssClassNames}"
+        data-store-view="${storeView.storeView}"
         data-store-root-url="${storeView.storeRootUrl}"
         data-cmp-data-layer-enabled="${page.data ? true : false}"
         data-graphql-endpoint="${storeView.graphqlEndpoint}"
-        data-graphql-method="${storeView.method}">
+        data-graphql-method="${storeView.method}"
+        data-http-headers="${storeView.httpHeaders}">
         <script data-sly-test.dataLayerEnabled="${page.data}">
             window.adobeDataLayer = window.adobeDataLayer || [];
             adobeDataLayer.push({

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -28,10 +28,15 @@ describe('CommerceGraphqlApi', () => {
     let graphqlApi;
     let fetchSpy;
     let fetchGraphqlSpy;
-    let httpHeaders = "{\"custom-1\":\"one\",\"custom-2\":\"two\"}";
+    let httpHeaders = '{"custom-1":"one","custom-2":"two"}';
     beforeEach(() => {
         fetchSpy = sinon.stub(CommerceGraphqlApi.prototype, '_fetch');
-        graphqlApi = new CommerceGraphqlApi({ endpoint: '/graphql', storeView: 'default', graphqlMethod: 'GET', headers: JSON.parse(httpHeaders) });
+        graphqlApi = new CommerceGraphqlApi({
+            endpoint: '/graphql',
+            storeView: 'default',
+            graphqlMethod: 'GET',
+            headers: JSON.parse(httpHeaders)
+        });
     });
 
     afterEach(() => {
@@ -100,7 +105,7 @@ describe('CommerceGraphqlApi', () => {
             assert.isTrue(fetchSpy.calledOnce);
             let options = fetchSpy.firstCall.args[1];
 
-            assert.include(options.headers, { "custom-1": "one", "custom-2":"two" });
+            assert.include(options.headers, { 'custom-1': 'one', 'custom-2': 'two' });
         });
     });
 

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -28,10 +28,10 @@ describe('CommerceGraphqlApi', () => {
     let graphqlApi;
     let fetchSpy;
     let fetchGraphqlSpy;
-
+    let httpHeaders = "{\"custom-1\":\"one\",\"custom-2\":\"two\"}";
     beforeEach(() => {
         fetchSpy = sinon.stub(CommerceGraphqlApi.prototype, '_fetch');
-        graphqlApi = new CommerceGraphqlApi({ endpoint: '/graphql', storeView: 'default', graphqlMethod: 'GET' });
+        graphqlApi = new CommerceGraphqlApi({ endpoint: '/graphql', storeView: 'default', graphqlMethod: 'GET', headers: JSON.parse(httpHeaders) });
     });
 
     afterEach(() => {
@@ -86,6 +86,21 @@ describe('CommerceGraphqlApi', () => {
             let options = fetchSpy.firstCall.args[1];
 
             assert.include(options.headers, { Store: 'my-special-store' });
+        });
+    });
+
+    it('passes the custom headers', () => {
+        const mockResult = { result: 'my-result' };
+        fetchSpy.resolves(mockResult);
+        graphqlApi.storeView = 'my-special-store';
+
+        let query = 'my-sample-query';
+
+        return graphqlApi._fetchGraphql(query, true).then(res => {
+            assert.isTrue(fetchSpy.calledOnce);
+            let options = fetchSpy.firstCall.args[1];
+
+            assert.include(options.headers, { "custom-1": "one", "custom-2":"two" });
         });
     });
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Users may configure additional HTTP headers to be sent with each Graphql request, via the `CIF HTTP Custom Headers configuration` service and the cloud service configuration. This PR updates the `MagentoGraphqlClient` to consume custom HTTP headers from the CA config.

## Related Issue

CIF-2097 

## Motivation and Context

Allow the components to consume the custom HTTP headers.

## How Has This Been Tested?

Unit testing, functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
