### PR TITLE
CIF-2206 - Fix category_id filters being present on category pages

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
@@ -156,7 +156,6 @@ public class SearchResultsServiceImpl implements SearchResultsService {
 
         // We will use the search filter service to retrieve all of the potential available filters the commerce system
         // has available for querying against
-
         List<FilterAttributeMetadata> availableFilters = searchFilterService.retrieveCurrentlyAvailableCommerceFilters(page);
         SorterKey currentSorterKey = prepareSorting(mutableSearchOptions, searchResultsSet);
 
@@ -181,8 +180,14 @@ public class SearchResultsServiceImpl implements SearchResultsService {
             request,
             resource);
 
-        final List<SearchAggregation> searchAggregations = extractSearchAggregationsFromResponse(products.getAggregations(),
+        List<SearchAggregation> searchAggregations = extractSearchAggregationsFromResponse(products.getAggregations(),
             mutableSearchOptions.getAllFilters(), availableFilters);
+
+        // Special treatment for category_id filter as this is always present and collides with category_uid filter (CIF-2206)
+        if (mutableSearchOptions.getCategoryUid().isPresent()) {
+            searchAggregations = searchAggregations.stream().filter(s -> !"category_id".equals(s.getIdentifier())).collect(Collectors
+                .toList());
+        }
 
         searchResultsSet.setTotalResults(products.getTotalCount());
         searchResultsSet.setProductListItems(productListItems);

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
@@ -185,8 +185,7 @@ public class SearchResultsServiceImpl implements SearchResultsService {
 
         // Special treatment for category_id filter as this is always present and collides with category_uid filter (CIF-2206)
         if (mutableSearchOptions.getCategoryUid().isPresent()) {
-            searchAggregations = searchAggregations.stream().filter(s -> !"category_id".equals(s.getIdentifier())).collect(Collectors
-                .toList());
+            searchAggregations.removeIf(a -> "category_id".equals(a.getIdentifier()));
         }
 
         searchResultsSet.setTotalResults(products.getTotalCount());

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
@@ -311,7 +311,7 @@ public class ProductListImplTest {
         // We want to make sure the category_id aggregation is not present
         Optional<SearchAggregation> categoryIdAggregation = searchAggregations.stream().filter(a -> a.getIdentifier().equals("category_id"))
             .findAny();
-        Assert.assertTrue(categoryIdAggregation.isEmpty());
+        Assert.assertFalse(categoryIdAggregation.isPresent());
 
         // We want to make sure all price ranges are properly processed
         SearchAggregation priceAggregation = searchAggregations.stream().filter(a -> a.getIdentifier().equals("price")).findFirst().get();

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImplTest.java
@@ -21,6 +21,7 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.http.HttpStatus;
@@ -305,7 +306,12 @@ public class ProductListImplTest {
 
         SearchResultsSet searchResultsSet = productListModel.getSearchResultsSet();
         List<SearchAggregation> searchAggregations = searchResultsSet.getSearchAggregations();
-        Assert.assertEquals(8, searchAggregations.size());
+        Assert.assertEquals(7, searchAggregations.size());
+
+        // We want to make sure the category_id aggregation is not present
+        Optional<SearchAggregation> categoryIdAggregation = searchAggregations.stream().filter(a -> a.getIdentifier().equals("category_id"))
+            .findAny();
+        Assert.assertTrue(categoryIdAggregation.isEmpty());
 
         // We want to make sure all price ranges are properly processed
         SearchAggregation priceAggregation = searchAggregations.stream().filter(a -> a.getIdentifier().equals("price")).findFirst().get();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With the UID changes the "Category Filter" (using category_id) became available on category pages as it could not be matched against the current category page identifier anymore (since it is a uid now).

Selecting the "Category Filter" does not make sense and leads to GraphQl errors because of combined `category_id` and `category_uid` filters.

This PR removes the `category_id` based aggregation for category pages. Full text search behavior has not changed.

## Related Issue

CIF-2206

## How Has This Been Tested?

Extended unit tests.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
