### PR TITLE
CIF-2209 - do not enable Sling model caching for MagentoGraphqlClientImpl

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/client/MagentoGraphqlClientImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/client/MagentoGraphqlClientImpl.java
@@ -68,8 +68,7 @@ import com.day.cq.wcm.api.PageManager;
  */
 @Model(
     adaptables = { SlingHttpServletRequest.class, Resource.class },
-    adapters = { MagentoGraphqlClient.class, MagentoGraphqlClientImpl.class },
-    cache = true)
+    adapters = { MagentoGraphqlClient.class, MagentoGraphqlClientImpl.class })
 public class MagentoGraphqlClientImpl implements MagentoGraphqlClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MagentoGraphqlClient.class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Regression: do not enable Sling model caching for MagentoGraphqlClientImpl because the `RequestOptions` for the GraphQlClient (which also influence caching behaviour) are cached with Sling Model caching.

## Related Issue

CIF-2209

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
