### PR TITLE
CIF-2208: remove category_uid request parameter on product lists

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/converters/AggregationOptionToSearchAggregationOptionConverter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/converters/AggregationOptionToSearchAggregationOptionConverter.java
@@ -59,10 +59,10 @@ public class AggregationOptionToSearchAggregationOptionConverter implements Func
             searchAggregationOption.setDisplayLabel(aggregationOption.getLabel());
         }
 
-        searchAggregationOption.setCount(aggregationOption.getCount());
+        searchAggregationOption.setCount(aggregationOption.getCount() != null ? aggregationOption.getCount() : 0);
         searchAggregationOption.setFilterValue(aggregationOption.getValue());
 
-        // this is done for convenience sake so we have all filters available
+        // this is done for convenience’ sake, so we have all filters available
         Map<String, String> newFilters = new HashMap<>(filters);
         newFilters.put(attributeCode, aggregationOption.getValue());
         searchAggregationOption.setAddFilterMap(newFilters.entrySet().stream()

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/converters/AggregationToSearchAggregationConverter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/converters/AggregationToSearchAggregationConverter.java
@@ -62,7 +62,7 @@ public class AggregationToSearchAggregationConverter implements Function<Aggrega
 
         SearchAggregationImpl searchAggregation = new SearchAggregationImpl();
         searchAggregation.setFilterable(filterable);
-        searchAggregation.setCount(aggregation == null ? 0 : aggregation.getCount());
+        searchAggregation.setCount(aggregation.getCount() != null ? aggregation.getCount() : 0);
         searchAggregation.setOptions(getOptions(aggregation, appliedFilters));
         searchAggregation.setDisplayLabel(aggregation.getLabel());
         searchAggregation.setIdentifier(identifier);

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.commerce.core.search.internal.services;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,7 @@ import com.adobe.cq.commerce.core.search.internal.models.SorterImpl;
 import com.adobe.cq.commerce.core.search.internal.models.SorterKeyImpl;
 import com.adobe.cq.commerce.core.search.models.FilterAttributeMetadata;
 import com.adobe.cq.commerce.core.search.models.SearchAggregation;
+import com.adobe.cq.commerce.core.search.models.SearchAggregationOption;
 import com.adobe.cq.commerce.core.search.models.SearchOptions;
 import com.adobe.cq.commerce.core.search.models.SearchResultsSet;
 import com.adobe.cq.commerce.core.search.models.Sorter;
@@ -82,6 +84,9 @@ import com.day.cq.wcm.api.PageManager;
 
 @Component(service = SearchResultsService.class)
 public class SearchResultsServiceImpl implements SearchResultsService {
+
+    private static final String CATEGORY_ID_FILTER = "category_id";
+    private static final String CATEGORY_UID_FILTER = "category_uid";
 
     @Reference
     private SearchFilterService searchFilterService;
@@ -184,10 +189,9 @@ public class SearchResultsServiceImpl implements SearchResultsService {
         List<SearchAggregation> searchAggregations = extractSearchAggregationsFromResponse(products.getAggregations(),
             mutableSearchOptions.getAllFilters(), availableFilters);
 
-        // Special treatment for category_id filter as this is always present and collides with category_uid filter (CIF-2206)
-        if (mutableSearchOptions.getCategoryUid().isPresent()) {
-            searchAggregations.removeIf(a -> "category_id".equals(a.getIdentifier()));
-        }
+        // special handling of category identifier(s)
+        removeCategoryIdAggregationIfNecessary(searchAggregations, mutableSearchOptions);
+        removeCategoryUidFilterEntriesIfPossible(searchAggregations, request);
 
         searchResultsSet.setTotalResults(products.getTotalCount());
         searchResultsSet.setProductListItems(productListItems);
@@ -357,8 +361,7 @@ public class SearchResultsServiceImpl implements SearchResultsService {
 
     /**
      * Generates a query string for the category specified in the retriever.
-     * 
-     * 
+     *
      * @param categoryRetriever
      * @return the query string
      */
@@ -468,4 +471,34 @@ public class SearchResultsServiceImpl implements SearchResultsService {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Removes the category_id filter from the search aggregations when category_uid filter is present because either cannot be combined
+     * with the other.
+     *
+     * @param aggs
+     * @param searchOptions
+     */
+    private void removeCategoryIdAggregationIfNecessary(List<SearchAggregation> aggs, SearchOptionsImpl searchOptions) {
+        // Special treatment for category_id filter as this is always present and collides with category_uid filter (CIF-2206)
+        if (searchOptions.getCategoryUid().isPresent()) {
+            aggs.removeIf(agg -> CATEGORY_ID_FILTER.equals(agg.getIdentifier()));
+        }
+    }
+
+    /**
+     * Removes the category_uid filter from all filter options' filter maps when the category uid can be retrieved from the request already.
+     *
+     * @param aggs
+     * @param request
+     */
+    private void removeCategoryUidFilterEntriesIfPossible(List<SearchAggregation> aggs, SlingHttpServletRequest request) {
+        String categoryUid = urlProvider.getCategoryIdentifier(request);
+        if (StringUtils.isNotBlank(categoryUid)) {
+            aggs.stream()
+                .map(SearchAggregation::getOptions)
+                .flatMap(Collection::stream)
+                .map(SearchAggregationOption::getAddFilterMap)
+                .forEach(filterMap -> filterMap.remove(CATEGORY_UID_FILTER, categoryUid));
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since we removed id support and with #602 we can further improve the urls on product list pages by removing the redundant category_uid url parameter.

## Related Issue

CIF-2208

## Motivation and Context

User friendly urls

## How Has This Been Tested?

Unit Tests, Manual using Venia

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
