### PR TITLE
CIF-2305 - fix raw product access for mapped product product list items

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/common/ProductListItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/common/ProductListItem.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import org.osgi.annotation.versioning.ConsumerType;
 
+import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 
 @ConsumerType
@@ -77,4 +78,11 @@ public interface ProductListItem extends ListItem {
     default Boolean isStaged() {
         return false;
     };
+
+    /**
+     * Returns the backend product using the GraphQL {@code ProductInterface}.
+     *
+     * @return The product.
+     */
+    ProductInterface getProduct();
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/common/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/common/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("2.0.0")
+@Version("2.1.0")
 package com.adobe.cq.commerce.core.components.models.common;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/converters/ProductToProductListItemConverter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/converters/ProductToProductListItemConverter.java
@@ -15,7 +15,6 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.commerce.core.search.internal.converters;
 
-import java.util.Locale;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
@@ -24,13 +23,9 @@ import org.apache.sling.api.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.core.components.internal.models.v1.common.PriceImpl;
 import com.adobe.cq.commerce.core.components.internal.models.v1.common.ProductListItemImpl;
-import com.adobe.cq.commerce.core.components.models.common.Price;
 import com.adobe.cq.commerce.core.components.models.common.ProductListItem;
 import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
-import com.adobe.cq.commerce.magento.graphql.GroupedProduct;
-import com.adobe.cq.commerce.magento.graphql.ProductImage;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import com.day.cq.wcm.api.Page;
@@ -44,7 +39,6 @@ public class ProductToProductListItemConverter implements Function<ProductInterf
 
     private final Resource parentResource;
     private final Page productPage;
-    private final Locale locale;
     private final UrlProvider urlProvider;
 
     private final SlingHttpServletRequest request;
@@ -53,7 +47,6 @@ public class ProductToProductListItemConverter implements Function<ProductInterf
                                              Resource parentResource) {
         this.parentResource = parentResource;
         this.productPage = productPage;
-        this.locale = productPage.getLanguage(false);
         this.request = request;
         this.urlProvider = urlProvider;
     }
@@ -61,27 +54,11 @@ public class ProductToProductListItemConverter implements Function<ProductInterf
     @Override
     public ProductListItem apply(final ProductInterface product) {
         try {
-            boolean isStartPrice = product instanceof GroupedProduct;
-            Price price = new PriceImpl(product.getPriceRange(), locale, isStartPrice);
-            final ProductImage smallImage = product.getSmallImage();
-
             String resourceType = parentResource.getResourceType();
             String prefix = StringUtils.substringAfterLast(resourceType, "/");
-            String path = parentResource.getPath();
-            String parentId = ComponentUtils.generateId(prefix, path);
+            String parentId = ComponentUtils.generateId(prefix, parentResource.getPath());
 
-            ProductListItem productListItem = new ProductListItemImpl(product.getSku(),
-                product.getUrlKey(),
-                product.getName(),
-                price,
-                smallImage == null ? null : smallImage.getUrl(),
-                smallImage == null ? null : smallImage.getLabel(),
-                productPage,
-                null, // search results aren't targeting specific variant
-                request,
-                urlProvider,
-                parentId,
-                product.getStaged());
+            ProductListItem productListItem = new ProductListItemImpl(product, productPage, null, request, urlProvider, parentId);
 
             return productListItem;
         } catch (Exception e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`ProductListItem` did not give any access to the full product retrieved from backend, hence extended queries with custom attributes did not work since the retrieved custom attributes could not be accessed.

With this the a project developer gets access to the entire product retrieved from the backend.

## Related Issue

CIF-2305

## How Has This Been Tested?

Added unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
