### PR TITLE
CIF-2334: remove skus from placeholder data

### DIFF
--- a/bundles/core/src/main/resources/productlist-component-placeholder-data.json
+++ b/bundles/core/src/main/resources/productlist-component-placeholder-data.json
@@ -7,7 +7,6 @@
       "items": [
         {
           "__typename": "SimpleProduct",
-          "sku": "sku-1",
           "name": "Product #1",
           "small_image": {
             "url": "/apps/core/cif/components/commerce/productlist/v1/productlist/images/catalog/category/product-thumbnail.png"
@@ -32,7 +31,6 @@
         },
         {
           "__typename": "SimpleProduct",
-          "sku": "sku-2",
           "name": "Product #2",
           "small_image": {
             "url": "/apps/core/cif/components/commerce/productlist/v1/productlist/images/catalog/category/product-thumbnail.png"
@@ -57,7 +55,6 @@
         },
         {
           "__typename": "SimpleProduct",
-          "sku": "sku-3",
           "name": "Product #3",
           "small_image": {
             "url": "/apps/core/cif/components/commerce/productlist/v1/productlist/images/catalog/category/product-thumbnail.png"
@@ -82,7 +79,6 @@
         },
         {
           "__typename": "SimpleProduct",
-          "sku": "sku-4",
           "name": "Product #4",
           "small_image": {
             "url": "/apps/core/cif/components/commerce/productlist/v1/productlist/images/catalog/category/product-thumbnail.png"
@@ -107,7 +103,6 @@
         },
         {
           "__typename": "SimpleProduct",
-          "sku": "sku-5",
           "name": "Product #5",
           "small_image": {
             "url": "/apps/core/cif/components/commerce/productlist/v1/productlist/images/catalog/category/product-thumbnail.png"
@@ -132,7 +127,6 @@
         },
         {
           "__typename": "SimpleProduct",
-          "sku": "sku-6",
           "name": "Product #6",
           "small_image": {
             "url": "/apps/core/cif/components/commerce/productlist/v1/productlist/images/catalog/category/product-thumbnail.png"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes the sku's from the productlist's placeholder data. This makes sure that they are not rendered to the markup as data attributes and so are not picked up by the associated content tab.

## Related Issue

CIF-2334


## How Has This Been Tested?

Unit Tests, Locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
