### PR TITLE
CIF-2268 - Removing product list component from category template breaks the page

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImpl.java
@@ -66,16 +66,20 @@ public class PageMetadataImpl implements PageMetadata {
 
         if (SiteNavigation.isProductPage(currentPage)) {
             Resource componentResource = findChildResourceWithType(resource, ProductImpl.RESOURCE_TYPE);
-            Product product = modelFactory.getModelFromWrappedRequest(request, componentResource, Product.class);
-            provider = product;
+            if (componentResource != null) {
+                Product product = modelFactory.getModelFromWrappedRequest(request, componentResource, Product.class);
+                provider = product;
+            }
         } else if (SiteNavigation.isCategoryPage(currentPage)) {
             Resource componentResource = findChildResourceWithType(resource, ProductListImpl.RESOURCE_TYPE);
             if (componentResource == null) {
                 componentResource = findChildResourceWithType(resource,
                     com.adobe.cq.commerce.core.components.internal.models.v1.productlist.ProductListImpl.RESOURCE_TYPE);
             }
-            ProductList productList = modelFactory.getModelFromWrappedRequest(request, componentResource, ProductList.class);
-            provider = productList;
+            if (componentResource != null) {
+                ProductList productList = modelFactory.getModelFromWrappedRequest(request, componentResource, ProductList.class);
+                provider = productList;
+            }
         }
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImplTest.java
@@ -180,6 +180,19 @@ public class PageMetadataImplTest {
     }
 
     @Test
+    public void testPageMetadataModelOnProductSpecificPageNoProduct() throws Exception {
+        String pagePath = "/content/venia/us/en/products/product-page/product-specific-page-no-product";
+
+        prepareModel(pagePath);
+        PageMetadata pageMetadataModel = context.request().adaptTo(PageMetadata.class);
+
+        Assert.assertNull(pageMetadataModel.getMetaDescription());
+        Assert.assertNull(pageMetadataModel.getMetaKeywords());
+        Assert.assertNull(pageMetadataModel.getMetaTitle());
+        Assert.assertNull(pageMetadataModel.getCanonicalUrl());
+    }
+
+    @Test
     public void testPageMetadataModelOnProductPageOnLaunch() throws Exception {
         testPageMetadataModelOnProductPage("/content/launches/2020/09/14/mylaunch/content/venia/us/en/products/product-page");
     }
@@ -250,6 +263,19 @@ public class PageMetadataImplTest {
         ProductList productListModel = context.request().adaptTo(ProductList.class);
         assertTrue(productListModel instanceof com.adobe.cq.commerce.core.components.internal.models.v2.productlist.ProductListImpl);
         assertTrue("The category has staged data", productListModel.isStaged());
+    }
+
+    @Test
+    public void testPageMetadataModelOnCategorySpecificPageNoProductlist() throws Exception {
+        String pagePath = "/content/venia/us/en/products/category-page/category-specific-page-no-productlist";
+
+        prepareModel(pagePath);
+        PageMetadata pageMetadataModel = context.request().adaptTo(PageMetadata.class);
+
+        Assert.assertNull(pageMetadataModel.getMetaDescription());
+        Assert.assertNull(pageMetadataModel.getMetaKeywords());
+        Assert.assertNull(pageMetadataModel.getMetaTitle());
+        Assert.assertNull(pageMetadataModel.getCanonicalUrl());
     }
 
     @Test

--- a/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
+++ b/bundles/core/src/test/resources/context/jcr-content-breadcrumb.json
@@ -82,6 +82,24 @@
                   }
                 }
               }
+            },
+            "product-specific-page-no-product": {
+              "jcr:primaryType": "cq:Page",
+              "jcr:content": {
+                "jcr:primaryType": "cq:PageContent",
+                "selectorFilter": "tiberius-gym-tank",
+                "sling:resourceType": "venia/components/page",
+                "root": {
+                  "responsivegrid": {
+                    "breadcrumb": {
+                      "sling:resourceType": "venia/components/commerce/breadcrumb",
+                      "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
+                      "startLevel": "3",
+                      "structureDepth": "2"
+                    }
+                  }
+                }
+              }
             }
           },
           "category-page": {
@@ -120,6 +138,24 @@
                     },
                     "productlist": {
                       "sling:resourceType": "core/cif/components/commerce/productlist/v2/productlist"
+                    }
+                  }
+                }
+              }
+            },
+            "category-specific-page-no-productlist": {
+              "jcr:primaryType": "cq:Page",
+              "jcr:content": {
+                "jcr:primaryType": "cq:PageContent",
+                "selectorFilter": "MTM=",
+                "sling:resourceType": "venia/components/page",
+                "root": {
+                  "responsivegrid": {
+                    "breadcrumb": {
+                      "sling:resourceType": "venia/components/commerce/breadcrumb",
+                      "sling:resourceSuperType": "core/wcm/components/breadcrumb/v2/breadcrumb",
+                      "startLevel": "3",
+                      "structureDepth": "2"
                     }
                   }
                 }


### PR DESCRIPTION
Fix the null pointer exception in PageMetadataImpl when the target component is not found on a product page or product list page.


## Related Issue

CIF-2268


## How Has This Been Tested?

JUnit, manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
