### PR TITLE
CIF-2298 - Menu cache flush is not working as expected

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/client/MagentoGraphqlClientImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/client/MagentoGraphqlClientImpl.java
@@ -34,6 +34,7 @@ import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
@@ -190,10 +191,13 @@ public class MagentoGraphqlClientImpl implements MagentoGraphqlClient {
         }
 
         this.httpHeaders = headers;
+        // In certain situations resource.getResourceType() returns an enforced resource type.
+        // We prefer the resource type of the component proxy for the cache name.
+        String cacheName = resource.getValueMap().get(ResourceResolver.PROPERTY_RESOURCE_TYPE, String.class);
         this.requestOptions = new RequestOptions()
             .withGson(QueryDeserializer.getGson())
             .withCachingStrategy(new CachingStrategy()
-                .withCacheName(resource.getResourceType())
+                .withCacheName(cacheName)
                 .withDataFetchingPolicy(DataFetchingPolicy.CACHE_FIRST))
             .withHeaders(headers.size() > 0 ? headers : null)
             .withHttpMethod(httpMethod);

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/client/MagentoGraphqlClientImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/client/MagentoGraphqlClientImpl.java
@@ -193,7 +193,7 @@ public class MagentoGraphqlClientImpl implements MagentoGraphqlClient {
         this.httpHeaders = headers;
         // In certain situations resource.getResourceType() returns an enforced resource type.
         // We prefer the resource type of the component proxy for the cache name.
-        String cacheName = resource.getValueMap().get(ResourceResolver.PROPERTY_RESOURCE_TYPE, String.class);
+        String cacheName = resource.getValueMap().get(ResourceResolver.PROPERTY_RESOURCE_TYPE, resource.getResourceType());
         this.requestOptions = new RequestOptions()
             .withGson(QueryDeserializer.getGson())
             .withCachingStrategy(new CachingStrategy()


### PR DESCRIPTION
Ensure that the resource type of the component proxy is used for cache name.
For instance currently the cache name for navigation component is: core/cif/components/structure/navigation/v1/navigation
while it's supposed to be: venia/components/commerce/navigation

## Related Issue

CIF-2298

Fixes #646.

## Motivation and Context

This was the initial behavior but internal modification changed it.

## How Has This Been Tested?

Manually, unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
