### PR TITLE
CIF-2312 - Respect "include_in_menu" property in navigation component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
@@ -16,8 +16,10 @@
 package com.adobe.cq.commerce.core.components.internal.models.v1.navigation;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -40,7 +42,8 @@ class GraphQLCategoryProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphQLCategoryProvider.class);
 
-    private static final Function<CategoryTreeQuery, CategoryTreeQuery> CATEGORIES_QUERY = q -> q.uid().name().urlPath().position();
+    private static final Function<CategoryTreeQuery, CategoryTreeQuery> CATEGORIES_QUERY = q -> q.uid().name().urlPath().position()
+        .includeInMenu();
     private final MagentoGraphqlClient magentoGraphqlClient;
 
     GraphQLCategoryProvider(MagentoGraphqlClient magentoGraphqlClient) {
@@ -80,6 +83,17 @@ class GraphQLCategoryProvider {
         if (children == null) {
             return Collections.emptyList();
         }
+
+        children = children.stream().filter(child -> {
+            if (child == null)
+                return false;
+
+            String name = child.getName();
+            Integer includeInMenu = child.getIncludeInMenu();
+
+            return name != null && (includeInMenu == null || includeInMenu > 0);
+        }).collect(Collectors.toList());
+        children.sort(Comparator.comparing(CategoryTree::getPosition));
 
         return children;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProvider.java
@@ -57,7 +57,7 @@ class GraphQLCategoryProvider {
         }
 
         if (StringUtils.isBlank(categoryIdentifier)) {
-            LOGGER.debug("Empty results identifier");
+            LOGGER.debug("Empty category identifier");
             return Collections.emptyList();
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
@@ -203,9 +203,6 @@ public class NavigationImpl implements Navigation {
             return;
         }
 
-        children = children.stream().filter(c -> c != null && c.getName() != null).collect(Collectors.toList());
-        children.sort(Comparator.comparing(CategoryTree::getPosition));
-
         for (CategoryTree child : children) {
             Map<String, String> params = new ParamsBuilder()
                 .uid(child.getUid().toString())

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
@@ -117,7 +117,7 @@ public class GraphQLCategoryProviderTest {
         GraphqlResponse<Query, Error> response = mock(GraphqlResponse.class);
         Query rootQuery = mock(Query.class);
         List<CategoryTree> list = mock(List.class);
-        CategoryTree category = mock(CategoryTree.class);
+        CategoryTree category = new CategoryTree();
 
         // test category not found
         when(graphqlClient.execute(anyString())).thenReturn(response);
@@ -131,7 +131,6 @@ public class GraphQLCategoryProviderTest {
 
         // test category children not found
         when(rootQuery.getCategoryList().get(0)).thenReturn(category);
-        when(category.getChildren()).thenReturn(null);
         Assert.assertTrue(categoryProvider.getChildCategories("13", 10).isEmpty());
     }
 
@@ -155,6 +154,22 @@ public class GraphQLCategoryProviderTest {
         Assert.assertEquals(6, categories.size());
         Assert.assertEquals(categories.stream().sorted(Comparator.comparing(CategoryTree::getPosition)).collect(Collectors.toList()),
             categories);
+
+        CategoryTree women = categories.get(1);
+        Assert.assertNotNull(women);
+        Assert.assertEquals("Women", women.getName());
+        List<CategoryTree> womenChildren = women.getChildren();
+        Assert.assertNotNull(womenChildren);
+        Assert.assertEquals(2, womenChildren.size());
+        CategoryTree tops = womenChildren.get(0);
+        Assert.assertNotNull(tops);
+        Assert.assertEquals("Tops", tops.getName());
+        List<CategoryTree> topsChildren = tops.getChildren();
+        Assert.assertNotNull(topsChildren);
+        Assert.assertEquals(3, topsChildren.size());
+        Assert.assertEquals(topsChildren.stream().sorted(Comparator.comparing(CategoryTree::getPosition)).collect(Collectors.toList()),
+            topsChildren);
+
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/GraphQLCategoryProviderTest.java
@@ -17,7 +17,9 @@ package com.adobe.cq.commerce.core.components.internal.models.v1.navigation;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.osgi.services.HttpClientBuilderFactory;
@@ -151,6 +153,8 @@ public class GraphQLCategoryProviderTest {
         // Test category children found
         List<CategoryTree> categories = categoryProvider.getChildCategories("Mg==", 5);
         Assert.assertEquals(6, categories.size());
+        Assert.assertEquals(categories.stream().sorted(Comparator.comparing(CategoryTree::getPosition)).collect(Collectors.toList()),
+            categories);
     }
 
     @Test

--- a/bundles/core/src/test/resources/graphql/magento-graphql-navigation-result.json
+++ b/bundles/core/src/test/resources/graphql/magento-graphql-navigation-result.json
@@ -187,6 +187,7 @@
             "uid": "Mzk=",
             "name": "What's New",
             "url_path": "what-is-new",
+            "include_in_menu": 1,
             "position": 1,
             "children": []
           },
@@ -200,7 +201,7 @@
           {
             "uid": "Mzh=",
             "name": "Hidden",
-            "url_path": "sale",
+            "url_path": "hidden",
             "include_in_menu": 0,
             "position": 7,
             "children": []

--- a/bundles/core/src/test/resources/graphql/magento-graphql-navigation-result.json
+++ b/bundles/core/src/test/resources/graphql/magento-graphql-navigation-result.json
@@ -196,6 +196,21 @@
             "url_path": "sale",
             "position": 6,
             "children": []
+          },
+          {
+            "uid": "Mzh=",
+            "name": "Hidden",
+            "url_path": "sale",
+            "include_in_menu": 0,
+            "position": 7,
+            "children": []
+          },
+
+          {
+            "uid": "Mzi=",
+            "url_path": "noname",
+            "position": 8,
+            "children": []
           }
         ]
       }

--- a/bundles/core/src/test/resources/graphql/magento-graphql-navigation-result.json
+++ b/bundles/core/src/test/resources/graphql/magento-graphql-navigation-result.json
@@ -41,13 +41,7 @@
                 "url_path": "women/tops-women",
                 "position": 1,
                 "children": [
-                  {
-                    "uid": "MjQ=",
-                    "name": "Jackets",
-                    "url_path": "women/tops-women/jackets-women",
-                    "position": 1,
-                    "children": []
-                  },
+
                   {
                     "uid": "MjU=",
                     "name": "Hoodies & Sweatshirts",
@@ -63,9 +57,17 @@
                     "children": []
                   },
                   {
+                    "uid": "MjQ=",
+                    "name": "Jackets",
+                    "url_path": "women/tops-women/jackets-women",
+                    "position": 1,
+                    "children": []
+                  },
+                  {
                     "uid": "Mjc=",
                     "name": "Bras & Tanks",
                     "url_path": "women/tops-women/tanks-women",
+                    "include_in_menu": 0,
                     "position": 4,
                     "children": []
                   }


### PR DESCRIPTION
 * don't include categories where the property include_in_menu is 0
 * minor refactoring for easier testing
 * updated unit tests extending them to also cover category ordering and exclusion of unnamed categories


## Related Issue

CIF-2312


## How Has This Been Tested?

Manually, unit tests.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
