### PR TITLE
CIF-2405: properly externalise URLs in product and category sitemaps

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -89,6 +89,7 @@
                         <Import-Package>
                             javax.annotation;version=0.0.0,
                             org.apache.sling.sitemap.*;resolution:=optional,
+                            com.adobe.aem.wcm.seo.*;resolution:=optional,
                             *
                         </Import-Package>
                     </instructions>
@@ -381,6 +382,12 @@
             <!-- TODO: remove when the API is provided by the sdk/uber-jar -->
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.sitemap</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.cq.wcm</groupId>
+            <artifactId>com.adobe.aem.wcm.seo</artifactId>
+            <version>1.0.5-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/CategoriesSitemapGenerator.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/CategoriesSitemapGenerator.java
@@ -28,10 +28,10 @@ import java.util.stream.Stream;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.sitemap.SitemapException;
 import org.apache.sling.sitemap.SitemapService;
 import org.apache.sling.sitemap.builder.Sitemap;
-import org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer;
 import org.apache.sling.sitemap.spi.generator.SitemapGenerator;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
@@ -73,7 +73,7 @@ public class CategoriesSitemapGenerator implements SitemapGenerator {
     @Reference
     private UrlProvider urlProvider;
     @Reference
-    private SitemapLinkExternalizer externalizer;
+    private SitemapLinkExternalizerProvider externalizerProvider;
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
     private SitemapCategoryFilter categoryFilter;
 
@@ -96,8 +96,9 @@ public class CategoriesSitemapGenerator implements SitemapGenerator {
             throw new SitemapException("Failed to build category sitemap at: " + sitemapRoot.getPath());
         }
 
-        // parameter map to be reused while iterating
-        UrlProvider.ParamsBuilder paramsBuilder = new UrlProvider.ParamsBuilder().page(externalizer.externalize(sitemapRoot));
+        ResourceResolver resourceResolver = sitemapRoot.getResourceResolver();
+        ;
+        SitemapLinkExternalizer externalizer = externalizerProvider.getExternalizer();
 
         String rootCategoryIdentifier = configuration.get(PN_MAGENTO_ROOT_CATEGORY_ID, String.class);
         Deque<String> categoryUids = new LinkedList<>(Arrays.asList(
@@ -133,12 +134,14 @@ public class CategoriesSitemapGenerator implements SitemapGenerator {
 
                 if (!categoryId.equals(rootCategoryIdentifier) && !ignoredByFilter) {
                     // skip root category, and ignored categories
-                    Map<String, String> params = paramsBuilder
+                    Map<String, String> params = new UrlProvider.ParamsBuilder()
+                        .page(categoryPage.getPath())
                         .uid(category.getUid().toString())
                         .urlKey(category.getUrlKey())
                         .urlPath(category.getUrlPath())
                         .map();
-                    sitemap.addUrl(urlProvider.toCategoryUrl(null, null, params));
+                    String url = externalizer.externalize(resourceResolver, params, map -> urlProvider.toCategoryUrl(null, null, map));
+                    sitemap.addUrl(url);
                 } else if (ignoredByFilter && LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Ignore category {}, not allowed by filter: {}", category.getUid(),
                         categoryFilter.getClass().getSimpleName());

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/SitemapLinkExternalizer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/SitemapLinkExternalizer.java
@@ -1,0 +1,45 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.commerce.core.components.internal.services.sitemap;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.sling.api.resource.ResourceResolver;
+
+import com.drew.lang.annotations.NotNull;
+
+/**
+ * An instance of this interface is provided by the {@link SitemapLinkExternalizerProvider} and implements a compatibility layer for either
+ * Sling's SitemapLinkExternalizer or, if available at runtime the Sites SEO's SitemapLinkExternalizer. The latter provides an advanced
+ * interface that allows to externalize a path directly.
+ */
+interface SitemapLinkExternalizer {
+
+    /**
+     * Externalizes the url returned by the given urlProvider function. This can either be done by externalizing the page parameter in the
+     * params map and passing the modified params map to the urlProvider function, or by passing the original params map to the url provider
+     * function and externalizing the result it returns.
+     *
+     * @param resourceResolver
+     * @param params
+     * @param urlProvider
+     * @return
+     */
+    @NotNull
+    String externalize(ResourceResolver resourceResolver, Map<String, String> params,
+        Function<Map<String, String>, String> urlProvider);
+}

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/SitemapLinkExternalizerProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/SitemapLinkExternalizerProvider.java
@@ -1,0 +1,105 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.commerce.core.components.internal.services.sitemap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
+
+/**
+ * This provider can be used to get an instance of {@link SitemapLinkExternalizer}. It takes into account that the Sites SEO api may not be
+ * available at all or in a version that does not contain the SitemapLinkExternalizer yet. In this case the returned
+ * {@link SitemapLinkExternalizer} will use the Apache Sling one as fallback.
+ */
+@Component(service = SitemapLinkExternalizerProvider.class)
+public class SitemapLinkExternalizerProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SitemapLinkExternalizerProvider.class);
+
+    @Reference
+    private org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer externalizerService;
+
+    private SitemapLinkExternalizer externalizer;
+
+    @Activate
+    protected void activate() {
+        // try to use the Sites SEO SitemapLinkExternalizer
+        try {
+            if (externalizerService instanceof com.adobe.aem.wcm.seo.sitemap.externalizer.SitemapLinkExternalizer) {
+                externalizer = new SeoSitemapLinkExternalizer(
+                    (com.adobe.aem.wcm.seo.sitemap.externalizer.SitemapLinkExternalizer) externalizerService);
+                return;
+            }
+        } catch (NoClassDefFoundError ex) {
+            LOGGER.debug("Could not load com.adobe.aem.wcm.seo.sitemap.externalizer.SitemapLinkExternalizer", ex);
+        }
+
+        // fallback to sling's SitemapLinkExternalizer
+        externalizer = new SlingSitemapLinkExternalizer(externalizerService);
+    }
+
+    SitemapLinkExternalizer getExternalizer() {
+        return externalizer;
+    }
+
+    private class SeoSitemapLinkExternalizer implements SitemapLinkExternalizer {
+
+        private final com.adobe.aem.wcm.seo.sitemap.externalizer.SitemapLinkExternalizer externalizer;
+
+        SeoSitemapLinkExternalizer(com.adobe.aem.wcm.seo.sitemap.externalizer.SitemapLinkExternalizer externalizer) {
+            this.externalizer = externalizer;
+        }
+
+        @Override
+        public String externalize(ResourceResolver resourceResolver, Map<String, String> params,
+            Function<Map<String, String>, String> urlProvider) {
+            // directly invoke the url provider and pass the returned path to the seo externalizer
+            return externalizer.externalize(resourceResolver, urlProvider.apply(params));
+        }
+    }
+
+    private class SlingSitemapLinkExternalizer implements SitemapLinkExternalizer {
+
+        private final org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer externalizer;
+
+        SlingSitemapLinkExternalizer(org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer externalizer) {
+            this.externalizer = externalizer;
+        }
+
+        @Override
+        public String externalize(ResourceResolver resourceResolver, Map<String, String> params,
+            Function<Map<String, String>, String> urlProvider) {
+            // get the page param, resolve and externalize it, then replace the param and pass it to the resource provider
+            return Optional.ofNullable(params.get(UrlProvider.PAGE_PARAM))
+                .map(resourceResolver::getResource)
+                .map(externalizer::externalize)
+                .map(externalPath -> {
+                    params.put(UrlProvider.PAGE_PARAM, externalPath);
+                    return urlProvider.apply(params);
+                })
+                .orElse(urlProvider.apply(params));
+        }
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/CategoriesSitemapGeneratorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/CategoriesSitemapGeneratorTest.java
@@ -92,6 +92,7 @@ public class CategoriesSitemapGeneratorTest {
         aemContext.registerInjectActivateService(graphqlClient);
         aemContext.registerService(SitemapCategoryFilter.class, categoryFilter);
         aemContext.registerService(SitemapLinkExternalizer.class, externalizer);
+        aemContext.registerInjectActivateService(new SitemapLinkExternalizerProvider());
         aemContext.registerInjectActivateService(urlProvider);
         aemContext.registerInjectActivateService(subject);
 

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/ProductsSitemapGeneratorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/ProductsSitemapGeneratorTest.java
@@ -84,6 +84,7 @@ public class ProductsSitemapGeneratorTest {
 
         aemContext.registerService(HttpClientBuilderFactory.class, new MockHttpClientBuilderFactory());
         aemContext.registerService(SitemapLinkExternalizer.class, externalizer);
+        aemContext.registerInjectActivateService(new SitemapLinkExternalizerProvider());
         aemContext.registerInjectActivateService(graphqlClient);
         aemContext.registerInjectActivateService(urlProvider);
         aemContext.registerInjectActivateService(new ProductsSitemapGenerator(), "pageSize", 2);

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/SitemapLinkExternalizerProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/sitemap/SitemapLinkExternalizerProviderTest.java
@@ -1,0 +1,101 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.commerce.core.components.internal.services.sitemap;
+
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
+import com.day.cq.wcm.api.Page;
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+import static org.apache.sling.hamcrest.ResourceMatchers.path;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SitemapLinkExternalizerProviderTest {
+
+    @Rule
+    public final AemContext aemContext = new AemContext();
+    private final SitemapLinkExternalizerProvider subject = new SitemapLinkExternalizerProvider();
+
+    @Test
+    public void testExternalizerWithSlingExternalizer() {
+        // given
+        Page page = aemContext.create().page("/content/venia/us/en");
+
+        org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer externalizerService = mock(
+            org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer.class);
+        when(externalizerService.externalize(argThat(path(page.getPath())))).thenReturn("http://venia.local/us/en");
+        aemContext.registerService(org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer.class, externalizerService);
+        aemContext.registerInjectActivateService(subject);
+
+        // when
+        SitemapLinkExternalizer externalizer = subject.getExternalizer();
+        Map<String, String> params = new UrlProvider.ParamsBuilder().page(page.getPath()).map();
+
+        // then
+        externalizer.externalize(aemContext.resourceResolver(), params, map -> {
+            // verify the page parameter got externalized
+            assertEquals("http://venia.local/us/en", map.get(UrlProvider.PAGE_PARAM));
+            return "";
+        });
+    }
+
+    @Test
+    public void testExternalizerFallbackWithSlingExternalizer() {
+        // given
+        org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer externalizerService = mock(
+            org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer.class);
+        aemContext.registerService(org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer.class, externalizerService);
+        aemContext.registerInjectActivateService(subject);
+
+        // when
+        SitemapLinkExternalizer externalizer = subject.getExternalizer();
+        Map<String, String> params = new UrlProvider.ParamsBuilder().page("/does/not/exist").map();
+
+        // then
+        externalizer.externalize(aemContext.resourceResolver(), params, map -> {
+            // verify the page parameter got externalized
+            assertEquals("/does/not/exist", map.get(UrlProvider.PAGE_PARAM));
+            return "";
+        });
+    }
+
+    @Test
+    public void testExternalizerWithSitesSeoExternalizer() {
+        // given
+        Page page = aemContext.create().page("/content/venia/us/en");
+
+        com.adobe.aem.wcm.seo.sitemap.externalizer.SitemapLinkExternalizer externalizerService = mock(
+            com.adobe.aem.wcm.seo.sitemap.externalizer.SitemapLinkExternalizer.class);
+        when(externalizerService.externalize(aemContext.resourceResolver(), page.getPath())).thenReturn("http://venia.local/us/en");
+        aemContext.registerService(org.apache.sling.sitemap.spi.common.SitemapLinkExternalizer.class, externalizerService);
+        aemContext.registerInjectActivateService(subject);
+
+        // when
+        SitemapLinkExternalizer externalizer = subject.getExternalizer();
+        Map<String, String> params = new UrlProvider.ParamsBuilder().page(page.getPath()).map();
+
+        // then
+        assertEquals("http://venia.local/us/en",
+            externalizer.externalize(aemContext.resourceResolver(), params, map -> map.get(UrlProvider.PAGE_PARAM)));
+    }
+}

--- a/examples/ui.config/src/content/jcr_root/apps/cif-components-examples/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
+++ b/examples/ui.config/src/content/jcr_root/apps/cif-components-examples/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
@@ -1,2 +1,2 @@
-productPageUrlFormat={{page}}.html/{{url_key}}.html\#{{variant_sku}}
-categoryPageUrlFormat={{page}}.html/{{url_path}}.html
+productPageUrlFormat="{{page}}.html/{{url_key}}.html\#{{variant_sku}}"
+categoryPageUrlFormat="{{page}}.html/{{url_path}}.html"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In this PR a newly introduced API of the Sites SEO is used which enables the SitemapGenerators to externalise ordinary paths using the same logic as it used for Resources. With this URLs can be externalised after they have been created by the UrlProvider.

## Related Issue

CIF-2405

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests, locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
