### PR TITLE
CIF-2367 [Accessibility][Product Teaser] The product image has an insufficient alternative text attribute

### DIFF
--- a/examples/all/pom.xml
+++ b/examples/all/pom.xml
@@ -149,6 +149,11 @@
                                     <artifactId>core.wcm.components.examples.ui.apps</artifactId>
                                     <filter>true</filter>
                                 </subPackage>
+                                <subPackage>
+                                    <groupId>com.adobe.cq</groupId>
+                                    <artifactId>core.wcm.components.examples.ui.config</artifactId>
+                                    <filter>true</filter>
+                                </subPackage>
                             </subPackages>
                         </configuration>
                     </plugin>
@@ -165,6 +170,12 @@
                 <dependency>
                     <groupId>com.adobe.cq</groupId>
                     <artifactId>core.wcm.components.examples.ui.apps</artifactId>
+                    <type>zip</type>
+                    <version>${core.wcm.components.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.adobe.cq</groupId>
+                    <artifactId>core.wcm.components.examples.ui.config</artifactId>
                     <type>zip</type>
                     <version>${core.wcm.components.version}</version>
                 </dependency>

--- a/examples/bundle/src/main/resources/graphql/magento-graphql-productteaser.json
+++ b/examples/bundle/src/main/resources/graphql/magento-graphql-productteaser.json
@@ -6,7 +6,8 @@
           "__typename": "SimpleProduct",
           "name": "Summit Watch",
           "image": {
-            "url": "/content/dam/core-components-examples/library/cif-sample-assets/catalog/product/summit-watch/mg03-br-0.jpg"
+            "url": "/content/dam/core-components-examples/library/cif-sample-assets/catalog/product/summit-watch/mg03-br-0.jpg",
+            "label": "Summit Watch"
           },
           "url_key": "summit-watch",
           "price_range": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The alt text for the product teaser component depends on the image label. This label was not included in the mock response used for the examples project.

Additionally, I added a missing WCM examples config package to the `include-wcm-components-examples` profile which blocked the installation when building the all package with that profile.

Closes #683.

## How Has This Been Tested?

Manually tested by installing the examples project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
