### PR TITLE
CIF-2578: fix createProductPageUrl caching

### DIFF
--- a/react-components/src/utils/__test__/createProductPageUrl.test.js
+++ b/react-components/src/utils/__test__/createProductPageUrl.test.js
@@ -26,11 +26,23 @@ describe('createProductPageUrl', () => {
         expect(url).toBeNull();
     });
 
-    it('creates a product page url for a product sku', () => {
+    it('creates a product page url for a product sku from body dataset', () => {
         document.body.dataset.storeRootUrl = '/content/venia/us/en.html';
 
-        const url = createProductPageUrl('my-product');
-
+        let url = createProductPageUrl('my-product');
         expect(url).toEqual('http://localhost/content/venia/us/en.cifproductredirect.html/my-product');
+        url = createProductPageUrl('my-other-product');
+        expect(url).toEqual('http://localhost/content/venia/us/en.cifproductredirect.html/my-other-product');
+    });
+
+    it('creates a product page url for a product sku from meta element', () => {
+        const el = { content: '{"storeRootUrl":"/content/venia2/us/en.html"}' };
+        // eslint-disable-next-line no-unused-vars
+        jest.spyOn(document, 'querySelector').mockImplementation(_ => el);
+
+        let url = createProductPageUrl('my-product');
+        expect(url).toEqual('http://localhost/content/venia2/us/en.cifproductredirect.html/my-product');
+        url = createProductPageUrl('my-other-product');
+        expect(url).toEqual('http://localhost/content/venia2/us/en.cifproductredirect.html/my-other-product');
     });
 });

--- a/react-components/src/utils/createProductPageUrl.js
+++ b/react-components/src/utils/createProductPageUrl.js
@@ -14,34 +14,26 @@
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-let storeRootUrl = null;
-
 export const createProductPageUrl = sku => {
     const url = new URL(window.location);
 
     // Provided by StoreConfigExporter
-    if (storeRootUrl) {
-        return storeRootUrl;
-    }
-
     let storeConfigEl = document.querySelector('meta[name="store-config"]');
-    let pathname;
+    let storeRootUrl;
 
     if (storeConfigEl) {
-        pathname = JSON.parse(storeConfigEl.content).storeRootUrl;
+        storeRootUrl = JSON.parse(storeConfigEl.content).storeRootUrl;
     } else {
         // TODO: deprecated - the store configuration on the <body> has been deprecated and will be removed
-        pathname = document.body.dataset.storeRootUrl;
+        storeRootUrl = document.body.dataset.storeRootUrl;
     }
 
-    if (!pathname) {
+    if (!storeRootUrl) {
         return null;
     }
 
-    const extension = '.html';
-    const path = pathname.substr(0, pathname.lastIndexOf('.'));
+    const path = storeRootUrl.substr(0, storeRootUrl.lastIndexOf('.'));
+    url.pathname = `${path}.cifproductredirect.html/${sku}`;
 
-    url.pathname = `${path}.cifproductredirect${extension}/${sku}`;
-
-    return (storeRootUrl = url.toString());
+    return url.toString();
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With #654 a caching mechanism was introduced to `createProductPageUrl()` in order to prevent querying for the store config meta element multiple times. This causes a regression as the caching stored a full product url and returned it in subsequent calls instead of just the storeRootUrl part. This PR removes the caching and adds more coverage to the method to validate the behaviour for subsequent calls.

## Related Issue

#654 CIF-2292
CIF-2578

## Motivation and Context

Regression introduced in CIF-2292

## How Has This Been Tested?

Unit tests and locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
