### PR TITLE
CIF-2614 - change to nightly schedule

### DIFF
--- a/.github/workflows/maven-deploy-to-library.yml
+++ b/.github/workflows/maven-deploy-to-library.yml
@@ -11,14 +11,31 @@ env:
  
 # Only run on a push to this branch
 on:
-  push:
-     branches: [ master ]
+  schedule:
+    - cron: '0 22 * * *'
   workflow_dispatch:
 
 jobs:
-  build:
+  check_date:
     runs-on: ubuntu-latest
- 
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
+      - name: Print latest_commit
+        run: echo ${{ github.sha }}
+      - name: Check latest commit is less than a day
+        id: should_run
+        continue-on-error: true
+        if: ${{ github.event_name == 'schedule' }}
+        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+
+  build:
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    runs-on: ubuntu-latest 
+    name: Deploy CIF Core Components Library
     steps:
       # Checkout this project into a sub folder
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2


### PR DESCRIPTION
## Description

Change to nightly schedule for CIF Core Components library deployments for aemcomponents.dev, but only if we have changes on the default branch.

For commit check in last 24h see https://stackoverflow.com/questions/63014786/how-to-schedule-a-github-actions-nightly-build-but-run-it-only-when-there-where

## Related Issue

CIF-2614

## Motivation and Context

Reduce the deploy frequency. At the moment we deploy on every PR merge to master. This is too ofter since it will also trigger for unimportant PRs like renovate dependency fixes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
