### PR TITLE
CIF-2580: disable wish lists from store configuration

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/account/MiniAccountImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/account/MiniAccountImpl.java
@@ -23,6 +23,8 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 
 import com.adobe.cq.commerce.core.components.internal.datalayer.DataLayerComponent;
 import com.adobe.cq.commerce.core.components.models.account.MiniAccount;
+import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
+import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
 
 @Model(
@@ -33,15 +35,20 @@ public class MiniAccountImpl extends DataLayerComponent implements MiniAccount {
 
     protected static final String RT_MINIACCOUNT_V2 = "core/cif/components/content/miniaccount/v2/miniaccount";
     protected static final String PN_STYLE_ENABLE_WISH_LIST = "enableWishList";
+    private static final String PN_CONFIG_ENABLE_WISH_LISTS = "enableWishLists";
 
     @ScriptVariable
     private Style currentStyle;
+    @ScriptVariable
+    private Page currentPage;
 
     private boolean wishListEnabled;
 
     @PostConstruct
     protected void initModel() {
-        wishListEnabled = currentStyle.get(PN_STYLE_ENABLE_WISH_LIST, MiniAccount.super.getWishListEnabled());
+        ComponentsConfiguration configProperties = currentPage.getContentResource().adaptTo(ComponentsConfiguration.class);
+        wishListEnabled = (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS, Boolean.TRUE) : Boolean.TRUE)
+            && currentStyle.get(PN_STYLE_ENABLE_WISH_LIST, MiniAccount.super.getWishListEnabled());
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
@@ -59,6 +59,7 @@ import com.adobe.cq.commerce.core.components.models.product.Variant;
 import com.adobe.cq.commerce.core.components.models.product.VariantAttribute;
 import com.adobe.cq.commerce.core.components.models.product.VariantValue;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
+import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.core.components.services.urls.ProductUrlFormat;
 import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
 import com.adobe.cq.commerce.core.components.storefrontcontext.ProductStorefrontContext;
@@ -112,6 +113,10 @@ public class ProductImpl extends DataLayerComponent implements Product {
      * Name of the boolean policy property indicating if the product component should show an add to wish list button or not.
      */
     private static final String PN_STYLE_ENABLE_ADD_TO_WISHLIST = "enableAddToWishList";
+    /**
+     * Name of a boolean configuration properties used by the CIF Configuration to store if the endpoint has wish lists enabled.
+     */
+    private static final String PN_CONFIG_ENABLE_WISH_LISTS = "enableWishLists";
 
     @Self
     private SlingHttpServletRequest request;
@@ -163,6 +168,7 @@ public class ProductImpl extends DataLayerComponent implements Product {
             currentStyle = Utils.getStyleProperties(request, resource);
         }
 
+        ComponentsConfiguration configProperties = currentPage.getContentResource().adaptTo(ComponentsConfiguration.class);
         // Get product selection from dialog
         ValueMap properties = request.getResource().getValueMap();
         String sku = properties.get(SELECTION_PROPERTY, String.class);
@@ -192,7 +198,8 @@ public class ProductImpl extends DataLayerComponent implements Product {
         }
 
         locale = currentPage.getLanguage(false);
-        enableAddToWishList = currentStyle.get(PN_STYLE_ENABLE_ADD_TO_WISHLIST, Product.super.getAddToWishListEnabled());
+        enableAddToWishList = (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS, Boolean.TRUE) : Boolean.TRUE)
+            && currentStyle.get(PN_STYLE_ENABLE_ADD_TO_WISHLIST, Product.super.getAddToWishListEnabled());
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productteaser/ProductTeaserImpl.java
@@ -42,6 +42,7 @@ import com.adobe.cq.commerce.core.components.models.common.CommerceIdentifier;
 import com.adobe.cq.commerce.core.components.models.common.Price;
 import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
+import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.core.components.services.urls.ProductUrlFormat;
 import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
 import com.adobe.cq.commerce.core.components.utils.SiteNavigation;
@@ -73,6 +74,7 @@ public class ProductTeaserImpl extends DataLayerComponent implements ProductTeas
 
     protected static final String RESOURCE_TYPE = "core/cif/components/commerce/productteaser/v1/productteaser";
     protected static final String PN_STYLE_ADD_TO_WISHLIST_ENABLED = "enableAddToWishList";
+    private static final String PN_CONFIG_ENABLE_WISH_LISTS = "enableWishLists";
 
     private static final String SELECTION_PROPERTY = "selection";
 
@@ -111,10 +113,13 @@ public class ProductTeaserImpl extends DataLayerComponent implements ProductTeas
     protected void initModel() {
         locale = currentPage.getLanguage(false);
 
+        ComponentsConfiguration configProperties = currentPage.getContentResource().adaptTo(ComponentsConfiguration.class);
+
         productPage = SiteNavigation.getProductPage(currentPage);
         if (productPage == null) {
             productPage = currentPage;
         }
+
         String selection = properties.get(SELECTION_PROPERTY, String.class);
         if (selection != null && !selection.isEmpty()) {
             if (selection.startsWith("/")) {
@@ -130,7 +135,8 @@ public class ProductTeaserImpl extends DataLayerComponent implements ProductTeas
             }
         }
 
-        enableAddToWishList = currentStyle.get(PN_STYLE_ADD_TO_WISHLIST_ENABLED, ProductTeaser.super.getAddToWishListEnabled());
+        enableAddToWishList = (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS, Boolean.TRUE) : Boolean.TRUE)
+            && currentStyle.get(PN_STYLE_ADD_TO_WISHLIST_ENABLED, ProductTeaser.super.getAddToWishListEnabled());
     }
 
     private boolean oneClickShoppable(ProductInterface product) {

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/account/MiniAccountImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/account/MiniAccountImplTest.java
@@ -17,6 +17,7 @@ package com.adobe.cq.commerce.core.components.internal.models.v1.account;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,10 +25,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.adobe.cq.commerce.core.components.models.account.MiniAccount;
+import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.core.testing.TestContext;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
 import com.day.cq.wcm.scripting.WCMBindingsConstants;
+import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
 import static org.junit.Assert.assertFalse;
@@ -59,6 +62,7 @@ public class MiniAccountImplTest {
 
         SlingBindings slingBindings = (SlingBindings) context.request().getAttribute(SlingBindings.class.getName());
         slingBindings.put(WCMBindingsConstants.NAME_CURRENT_STYLE, style);
+        slingBindings.put(WCMBindingsConstants.NAME_CURRENT_PAGE, currentPage);
 
         when(style.get(any(), anyBoolean())).then(i -> i.getArgumentAt(1, Boolean.class));
     }
@@ -83,6 +87,28 @@ public class MiniAccountImplTest {
     @Test
     public void testWishListEnabled() {
         when(style.get(eq(MiniAccountImpl.PN_STYLE_ENABLE_WISH_LIST), anyBoolean())).thenReturn(Boolean.TRUE);
+        MiniAccount miniAccount = context.request().adaptTo(MiniAccount.class);
+
+        assertNotNull(miniAccount);
+        assertTrue(miniAccount.getWishListEnabled());
+    }
+
+    @Test
+    public void testWishListEnabledConfigDisabled() {
+        when(style.get(eq(MiniAccountImpl.PN_STYLE_ENABLE_WISH_LIST), anyBoolean())).thenReturn(Boolean.TRUE);
+        context.registerAdapter(Resource.class, ComponentsConfiguration.class,
+            new ComponentsConfiguration(new ValueMapDecorator(ImmutableMap.of("enableWishLists", Boolean.FALSE))));
+        MiniAccount miniAccount = context.request().adaptTo(MiniAccount.class);
+
+        assertNotNull(miniAccount);
+        assertFalse(miniAccount.getWishListEnabled());
+    }
+
+    @Test
+    public void testWishListEnabledConfigEnabled() {
+        when(style.get(eq(MiniAccountImpl.PN_STYLE_ENABLE_WISH_LIST), anyBoolean())).thenReturn(Boolean.TRUE);
+        context.registerAdapter(Resource.class, ComponentsConfiguration.class,
+            new ComponentsConfiguration(new ValueMapDecorator(ImmutableMap.of("enableWishLists", Boolean.TRUE))));
         MiniAccount miniAccount = context.request().adaptTo(MiniAccount.class);
 
         assertNotNull(miniAccount);

--- a/extensions/product-recs/bundle/pom.xml
+++ b/extensions/product-recs/bundle/pom.xml
@@ -325,6 +325,11 @@
     <!-- ====================================================================== -->
     <dependencies>
         <dependency>
+            <groupId>com.adobe.commerce.cif</groupId>
+            <artifactId>core-cif-components-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
         </dependency>
@@ -359,6 +364,23 @@
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.commerce.cif</groupId>
+            <artifactId>graphql-client</artifactId>
+            <version>${graphql.client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.commerce.cif</groupId>
+            <artifactId>magento-graphql</artifactId>
+            <version>${magento.graphql.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.cq</groupId>
+            <artifactId>core.wcm.components.core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Testing -->

--- a/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/internal/models/v1/productrecommendations/ProductRecommendationsImpl.java
+++ b/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/internal/models/v1/productrecommendations/ProductRecommendationsImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.commerce.extensions.recommendations.internal.models.v1.prod
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Via;
@@ -24,9 +25,11 @@ import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
+import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.extensions.recommendations.internal.models.v1.common.PriceRangeImpl;
 import com.adobe.cq.commerce.extensions.recommendations.models.common.PriceRange;
 import com.adobe.cq.commerce.extensions.recommendations.models.productrecommendations.ProductRecommendations;
+import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
 
 @Model(
@@ -51,11 +54,12 @@ public class ProductRecommendationsImpl implements ProductRecommendations {
     private static final String DEFAULT_TITLE = "Recommended products";
     private static final String USED_FILTER = "usedFilter";
     private static final String PN_STYLE_ENABLE_ADD_TO_WISHLIST = "enableAddToWishList";
+    private static final String PN_CONFIG_ENABLE_WISH_LISTS = "enableWishLists";
 
-    @Self
-    protected SlingHttpServletRequest request;
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     private Style currentStyle;
+    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    private Page currentPage;
     @Self
     @Via("resource")
     private ValueMap props;
@@ -134,7 +138,10 @@ public class ProductRecommendationsImpl implements ProductRecommendations {
 
     @Override
     public boolean getAddToWishListEnabled() {
+        Resource configResource = currentPage != null ? currentPage.getContentResource() : null;
+        ComponentsConfiguration configProperties = configResource != null ? configResource.adaptTo(ComponentsConfiguration.class) : null;
         Boolean defaultValue = ProductRecommendations.super.getAddToWishListEnabled();
-        return currentStyle != null ? currentStyle.get(PN_STYLE_ENABLE_ADD_TO_WISHLIST, defaultValue) : defaultValue;
+        return (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS, Boolean.TRUE) : Boolean.TRUE)
+            && currentStyle != null ? currentStyle.get(PN_STYLE_ENABLE_ADD_TO_WISHLIST, defaultValue) : defaultValue;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wish lists can be enabled/disabled per store configuration. this information is available as part of the store config query. However as the configuration does not change often, it does not make much sense to query it for each page rendering that requires this information. Because of that we added a (feature) configuration to the CIF context aware configuration which can be automatically set from the store configuration with the next release of the CIF addon. 

## Related Issue

CIF-2580
CIF-2407

## How Has This Been Tested?

Unit Tests, manual verifcation

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
