### PR TITLE
CIF-2602: Grouped products added multiple times to Wish List

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToWishlist.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToWishlist.js
@@ -23,9 +23,13 @@ class AddToWishlist {
     constructor(config) {
         this._element = config.element;
         let parent_sku = config.product.querySelector(AddToWishlist.selectors.sku).innerHTML;
+        let grouped = config.product.dataset.grouped !== undefined;
+        let productId = config.product.id;
 
         this._state = {
-            parent_sku
+            parent_sku,
+            grouped,
+            productId
         };
 
         // Add click handler to add to wishlist button
@@ -51,21 +55,30 @@ class AddToWishlist {
         const selections = Array.from(document.querySelectorAll(AddToWishlist.selectors.quantity)).filter(selection => {
             return parseInt(selection.value) > 0;
         });
-        const items = selections.map(selection => {
-            const item = {
-                productId: selection.dataset.productId,
-                sku: selection.dataset.productSku,
-                quantity: selection.value
-            };
 
-            if (item.sku != this._state.parent_sku) {
-                item.parent_sku = this._state.parent_sku;
-            }
+        if (grouped) {
+            return [
+                {
+                    productId: this._state.productId,
+                    sku: this._state.parent_sku,
+                    quantity: 1
+                }
+            ];
+        } else {
+            return selections.map(selection => {
+                const item = {
+                    productId: selection.dataset.productId,
+                    sku: selection.dataset.productSku,
+                    quantity: selection.value
+                };
 
-            return item;
-        });
+                if (item.sku != this._state.parent_sku) {
+                    item.parent_sku = this._state.parent_sku;
+                }
 
-        return items;
+                return item;
+            });
+        }
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToWishlist.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToWishlist.js
@@ -56,7 +56,7 @@ class AddToWishlist {
             return parseInt(selection.value) > 0;
         });
 
-        if (grouped) {
+        if (this._state.grouped) {
             return [
                 {
                     productId: this._state.productId,

--- a/ui.apps/test/components/commerce/product/addToWishlistTest.js
+++ b/ui.apps/test/components/commerce/product/addToWishlistTest.js
@@ -78,6 +78,32 @@ describe('Product', () => {
             assert.equal(dispatchEventSpy.getCall(0).args[0].detail[0].quantity, 5);
         });
 
+        it('dispatches an event on click for grouped product', () => {
+            setupPage(`
+                <div data-cmp-is="product" data-grouped>
+                    <div class="productFullDetail__details">
+                        <span role="sku">parent-sku</span>
+                    </div>
+                    <div class="productFullDetail__cartActions">
+                        <button class="button__root_normalPriority" data-cmp-is="add-to-wish-list">
+                    </div>
+                    <div class="productFullDetail__quantity">
+                        <select data-product-sku="my-sample-sku">
+                            <option value="5" selected></option>
+                        </select>
+                    </div>
+                </div>
+            `);
+
+            let addToWishlist = new AddToWishlist({ element: addToWishlistRoot, product: productRoot });
+            addToWishlistRoot.click();
+
+            sinon.assert.calledOnce(dispatchEventSpy);
+            assert.equal(dispatchEventSpy.getCall(0).args[0].type, 'aem.cif.add-to-wishlist');
+            assert.equal(dispatchEventSpy.getCall(0).args[0].detail[0].sku, 'parent-sku');
+            assert.equal(dispatchEventSpy.getCall(0).args[0].detail[0].quantity, 1);
+        });
+
         it('dispatches an event on click with variant selected', () => {
             setupPage(`
                 <div data-cmp-is="product">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When adding a grouped product to wishlist, use the sku of the grouped product, not individual items

## Related Issue

CIF-2602

## Motivation and Context

When adding group products to the wish list they get randomly added multiple times (in tests twice). Compared to venia.magento.com we add each product with a parent_sku, pwa studio only adds the grouped product itself.

## How Has This Been Tested?

unit test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
