### PR TITLE
CIF-2560: enable preview filter for product pickers

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -135,7 +135,8 @@
                                                 multiple="true"
                                                 name="./selectorFilter"
                                                 rootPath="/var/commerce/products"
-                                                selectionId="slug">
+                                                selectionId="slug"
+                                                enablePreviewDateFilter="{Boolean}true">
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -111,7 +111,8 @@
                                                 multiple="true"
                                                 name="./selectorFilter"
                                                 rootPath="/var/commerce/products"
-                                                selectionId="slug">
+                                                selectionId="slug"
+                                                enablePreviewDateFilter="{Boolean}true">
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
@@ -86,7 +86,8 @@
                                                 multiple="true"
                                                 name="./cq:products"
                                                 rootPath="/var/commerce/products"
-                                                selectionId="combinedSku">
+                                                selectionId="combinedSku"
+                                                enablePreviewDateFilter="{Boolean}true">
                                                 <granite:data
                                                     jcr:primaryType="nt:unstructured"
                                                     metaType="text"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR enables the preview date filter for product pickers in the Page properties.

Inside a Launch and when using Timewrap, the product pickers are already preconfigured for staged catalog data. For places that are not accessible in this context, the same should be possible using a filter inside the picker itself.

## Related Issue

CIF-2560

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
