### PR TITLE
CIF-2650 - Remove unused filter attribute of product picker

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/_cq_dialog/.content.xml
@@ -17,7 +17,6 @@
                         sling:resourceType="commerce/gui/components/common/cifproductfield"
                         fieldDescription="The product that should be displayed by the product detail component."
                         fieldLabel="Manual Product Selection"
-                        filter="folderOrProduct"
                         name="./selection"
                         selectionId="sku"/>
                     <well

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/_cq_dialog/.content.xml
@@ -19,7 +19,6 @@
                         <field jcr:primaryType="nt:unstructured" 
                             sling:resourceType="commerce/gui/components/common/cifproductfield" 
                             fieldLabel="Product" 
-                            filter="folderOrProductOrVariant" 
                             name="./product" 
                             selectionId="combinedSku" />
                     </content>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
@@ -34,7 +34,6 @@
                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                 fieldDescription="The product or product variant displayed by the teaser"
                                                 fieldLabel="Select Product"
-                                                filter="folderOrProductOrVariant"
                                                 name="./selection"
                                                 selectionId="combinedSku"/>
                                             <call-to-action

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/relatedproducts/v1/relatedproducts/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/relatedproducts/v1/relatedproducts/_cq_dialog/.content.xml
@@ -16,7 +16,6 @@
                         sling:resourceType="commerce/gui/components/common/cifproductfield" 
                         fieldDescription="Base product used to display related products. If empty, the component will fetch the product based on the selector of the URL." 
                         fieldLabel="Base product - Leave empty to use the current product of the generic product page." 
-                        filter="folderOrProduct" 
                         name="./product" 
                         selectionId="sku" />
                     <relationType jcr:primaryType="nt:unstructured" 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
@@ -82,7 +82,6 @@
                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                 fieldDescription="Select the products associated with this experience fragment variation."
                                                 fieldLabel="Product SKUs."
-                                                filter="folderOrProductOrVariant"
                                                 multiple="true"
                                                 name="./cq:products"
                                                 rootPath="/var/commerce/products"

--- a/ui.apps/test/components/content/teaser/teaserConfigTest.js
+++ b/ui.apps/test/components/content/teaser/teaserConfigTest.js
@@ -211,7 +211,7 @@ import jQuery from '../../../clientlibs/common/jQueryMockForTest';
                                                                              data-cmp-teaser-v1-dialog-edit-hook="actionProduct"
                                                                              data-foundation-validation=""
                                                                              name="./actions/item0/productSlug"
-                                                                             pickersrc="/mnt/overlay/commerce/gui/content/common/cifproductfield/picker.html?root=%2fvar%2fcommerce%2fproducts&amp;filter=folderOrProduct&amp;selectionCount=single&amp;selectionId=slug"
+                                                                             pickersrc="/mnt/overlay/commerce/gui/content/common/cifproductfield/picker.html?root=%2fvar%2fcommerce%2fproducts&amp;selectionCount=single&amp;selectionId=slug"
                                                                              placeholder="Product slug" role="combobox">
                                                         <div class="foundation-autocomplete-inputgroupwrapper">
                                                             <div class="coral-InputGroup">
@@ -388,7 +388,7 @@ import jQuery from '../../../clientlibs/common/jQueryMockForTest';
                                                                          data-cmp-teaser-v1-dialog-edit-hook="actionProduct"
                                                                          data-foundation-validation=""
                                                                          name="productSlug"
-                                                                         pickersrc="/mnt/overlay/commerce/gui/content/common/cifproductfield/picker.html?root=%2fvar%2fcommerce%2fproducts&amp;filter=folderOrProduct&amp;selectionCount=single&amp;selectionId=slug"
+                                                                         pickersrc="/mnt/overlay/commerce/gui/content/common/cifproductfield/picker.html?root=%2fvar%2fcommerce%2fproducts&amp;selectionCount=single&amp;selectionId=slug"
                                                                          placeholder="Product slug">
                                                     <coral-overlay class="foundation-picker-buttonlist"
                                                                    data-foundation-picker-buttonlist-src=""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* The `filter` attribute was deprecated some time ago when we started to derive it from the `selectionId`. Since its value is not respected anymore, we can simply remove it. This applies to usage of the CIF Core Components together with the CIF add-on only.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
