### PR TITLE
CIF-2561: enable preview filter for category pickers

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -110,7 +110,8 @@
                                                 fieldLabel="Category ids for which this page will be used."
                                                 multiple="{Boolean}true"
                                                 name="./selectorFilter"
-                                                selectionId="uidAndUrlPath">
+                                                selectionId="uidAndUrlPath"
+                                                enablePreviewDateFilter="{Boolean}true">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -124,7 +124,8 @@
                                                 fieldLabel="Category ids for which this page will be used."
                                                 multiple="{Boolean}true"
                                                 name="./selectorFilter"
-                                                selectionId="urlPath">
+                                                selectionId="urlPath"
+                                                enablePreviewDateFilter="{Boolean}true">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>
@@ -135,7 +136,8 @@
                                                 fieldLabel="Category ids for which this page will be used."
                                                 multiple="{Boolean}true"
                                                 name="./useForCategories"
-                                                selectionId="urlPath">
+                                                selectionId="urlPath"
+                                                enablePreviewDateFilter="{Boolean}true">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="product"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/xfpage/v1/xfpage/_cq_dialog/.content.xml
@@ -111,7 +111,8 @@
                                                 fieldDescription="Select the categories associated with this experience fragment variation."
                                                 fieldLabel="Category IDs."
                                                 multiple="{Boolean}true"
-                                                name="./cq:categories">
+                                                name="./cq:categories"
+                                                enablePreviewDateFilter="{Boolean}true">
                                                 <granite:data
                                                     jcr:primaryType="nt:unstructured"
                                                     metaType="text"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR enables the preview date filter for category pickers in the Page properties.

Inside a Launch and when using Timewrap, the category pickers are already preconfigured for staged catalog data. For places that are not accessible in this context, the same should be possible using a filter inside the picker itself.

## Related Issue

CIF-2561

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
