### PR TITLE
CIF-2969: fix overlay handling in 6.5

### DIFF
--- a/extensions/product-recs/content/src/main/content/jcr_root/apps/core/cif/extensions/product-recs/components/productrecommendations/v1/productrecommendations/clientlibs/editorhook/js/overlayHandling.js
+++ b/extensions/product-recs/content/src/main/content/jcr_root/apps/core/cif/extensions/product-recs/components/productrecommendations/v1/productrecommendations/clientlibs/editorhook/js/overlayHandling.js
@@ -43,6 +43,11 @@
             'aem.cif.product-recs-loaded',
             removeOverlayInContentFrame
         );
-        ns.ContentFrame.messageChannel.subscribeRequestMessage('cif-destroy-overlay', removeOverlayInEditorFrame);
+        if (ns.ContentFrame.messageChannel) {
+            ns.ContentFrame.messageChannel.subscribeRequestMessage('cif-destroy-overlay', removeOverlayInEditorFrame);
+        } else if (ns.ContentFrame.subscribeRequestMessage) {
+            // support for 6.5
+            ns.ContentFrame.subscribeRequestMessage('cif-destroy-overlay', removeOverlayInEditorFrame);
+        }
     });
 })(Granite.author, jQuery, jQuery(document));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When implementing the overlay handling of the product recommendations component we introduced the usage of an API that is not available in 6.5 causing an error to be logged. This PR fixes that by using the API available in 6.5 instead.

## Related Issue

CIF-2969
CIF-2240

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
