### PR TITLE
CIF-2474: enable the Commerce Pages on catalog pages

### DIFF
--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/CatalogPagePropertiesIT.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/CatalogPagePropertiesIT.java
@@ -79,9 +79,9 @@ public class CatalogPagePropertiesIT {
         elements = doc.select("coral-panel coral-checkbox coral-checkbox-label:contains(Show catalog page)");
         Assert.assertEquals(1, elements.size());
 
-        // Check that commerce pages section is not displayed
+        // Check that commerce pages section are displayed
         elements = doc.select("coral-panel .coral-Form-fieldset-legend:contains(Commerce Pages)");
-        Assert.assertEquals(0, elements.size());
+        Assert.assertEquals(1, elements.size());
     }
 
     @After

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -48,9 +48,18 @@
                                     <pagesSection jcr:primaryType="nt:unstructured"
                                         jcr:title="Commerce Pages"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
-                                        <granite:rendercondition jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="core/cif/components/renderconditions/pagetype"
-                                            pageType="landing"/>
+                                        <granite:rendercondition
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/renderconditions/or">
+                                            <landingPageCondition
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/pagetype"
+                                                pageType="landing"/>
+                                            <catalogPageCondition
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/pagetype"
+                                                pageType="catalog"/>
+                                        </granite:rendercondition>
                                         <items jcr:primaryType="nt:unstructured">
                                             <productPage
                                                 jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When having a site that features multiple "shop" entries with different product/category pages it must be possible for editors to define the references to those. From an implementation perspective this is already possible as the `cq:cifProductPage` and `cq:cifCategoryPage` properties are inherited down the hierarchy. However it is not possible to set them anywhere else than on the landing page.

This PR enables these properties to be set on the catalog pages.

## Related Issue

CIF-2474

## Motivation and Context

Commerce quick site creation

## How Has This Been Tested?

Locally, existing ITs adapted accordingly

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
