### PR TITLE
releng - Replace Azul JDK with OpenJDK images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ common:
   selenium_test_steps: &selenium_test_steps
     steps:
       - checkout
+      - browser-tools/install-browser-tools
       - *restore_cache
       - attach_workspace:
           at: /home/circleci/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,10 @@ common:
 executors:
   cif_executor:
     docker:
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-openjdk-azul:11-stretch-node-browsers
-        <<: *docker_auth
+      - image: cimg/openjdk:11.0-browsers
   cif_executor_java8:
     docker:
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-openjdk-azul:8-stretch-node-browsers
-        <<: *docker_auth
+      - image: cimg/openjdk:8.0-browsers
   test_executor_cloudready:
     docker:
       - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.4-azul-jdk11
@@ -88,9 +86,6 @@ jobs:
     steps:
       - checkout
       - *restore_cache
-      - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
       - run:
           name: Build
           command: node .circleci/ci/build.js
@@ -126,9 +121,6 @@ jobs:
       - checkout
       - *restore_cache
       - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
-      - run:
           name: Build
           command: node .circleci/ci/build.js
       - store_artifacts:
@@ -136,7 +128,7 @@ jobs:
 
   karma:
     docker:
-      - image: circleci/node:lts-browsers@sha256:4e85b1aa632b9f5a0b9d6247485a9b151f953b2ff588c649aa5dce08b3f6d7d5
+      - image: cimg/node:lts-browsers
     steps:
       - checkout
       - run:
@@ -160,12 +152,9 @@ jobs:
 
   jest:
     docker:
-      - image: circleci/node:lts-browsers@sha256:4e85b1aa632b9f5a0b9d6247485a9b151f953b2ff588c649aa5dce08b3f6d7d5
+      - image: cimg/node:lts-browsers
     steps:
       - checkout
-      - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
       - run:
           name: Provision
           command: |
@@ -186,12 +175,9 @@ jobs:
 
   jest-extension:
     docker:
-      - image: circleci/node:lts-browsers@sha256:4e85b1aa632b9f5a0b9d6247485a9b151f953b2ff588c649aa5dce08b3f6d7d5
+      - image: cimg/node:lts-browsers
     steps:
       - checkout
-      - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
       - run:
           name: Provision (Core)
           command: |
@@ -262,9 +248,6 @@ jobs:
       - checkout
       - *restore_cache
       - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
-      - run:
           name: Release
           # Only performs a 'mvn deploy' after the 'mvn release:prepare' because circleCI
           # already checks out the git tag like 'mvn release:perform' would do.
@@ -280,9 +263,6 @@ jobs:
     steps:
       - checkout
       - *restore_cache
-      - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
       - run:
           name: Generate Queries
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@1.1.1
+  browser-tools: circleci/browser-tools@1.2.4
 
 common:
   restore_cache: &restore_cache
@@ -87,6 +88,9 @@ jobs:
       - checkout
       - *restore_cache
       - run:
+          name: Update permissions
+          command: sudo chown -R circleci /usr/local/lib/node_modules
+      - run:
           name: Build
           command: node .circleci/ci/build.js
       - save_cache:
@@ -121,6 +125,9 @@ jobs:
       - checkout
       - *restore_cache
       - run:
+          name: Update permissions
+          command: sudo chown -R circleci /usr/local/lib/node_modules
+      - run:
           name: Build
           command: node .circleci/ci/build.js
       - store_artifacts:
@@ -131,6 +138,7 @@ jobs:
       - image: cimg/node:lts-browsers
     steps:
       - checkout
+      - browser-tools/install-browser-tools
       - run:
           name: Provision
           command: |
@@ -156,6 +164,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update permissions
+          command: sudo chown -R circleci /usr/local/lib/node_modules
+      - run:
           name: Provision
           command: |
             node -v
@@ -178,6 +189,9 @@ jobs:
       - image: cimg/node:lts-browsers
     steps:
       - checkout
+      - run:
+          name: Update permissions
+          command: sudo chown -R circleci /usr/local/lib/node_modules
       - run:
           name: Provision (Core)
           command: |
@@ -248,6 +262,9 @@ jobs:
       - checkout
       - *restore_cache
       - run:
+          name: Update permissions
+          command: sudo chown -R circleci /usr/local/lib/node_modules
+      - run:
           name: Release
           # Only performs a 'mvn deploy' after the 'mvn release:prepare' because circleCI
           # already checks out the git tag like 'mvn release:perform' would do.
@@ -263,6 +280,9 @@ jobs:
     steps:
       - checkout
       - *restore_cache
+      - run:
+          name: Update permissions
+          command: sudo chown -R circleci /usr/local/lib/node_modules
       - run:
           name: Generate Queries
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,15 +69,15 @@ executors:
       - image: cimg/openjdk:8.0-browsers
   test_executor_cloudready:
     docker:
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.4-azul-jdk11
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.6-openjdk11
         <<: *docker_auth
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem-cloudready:5852-azul
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem-cloudready:6582-openjdk11
         <<: *docker_auth
   test_executor_655:
     docker:
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.4-azul-jdk11
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.6-openjdk11
         <<: *docker_auth
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem:6.5.8-azul
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem:6.5.8-openjdk11
         <<: *docker_auth
 
 jobs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Replaced Azul JDK images with new ones using OpenJDK.
* Adapted to new pattern to install browsers for UI testing via `circleci/browser-tools` orb, since they are no longer included in the images.

## How Has This Been Tested?

Via CircleCI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
