### PR TITLE
CIF-2766 - Commerce property tab for category template page is broken

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -131,7 +131,7 @@
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>
                                             </categoryFilter>
-                                            <categoryFilter jcr:primaryType="nt:unstructured"
+                                            <categoryFilterProductPage jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                                                 fieldDescription="Category ids for which this page will be used."
                                                 fieldLabel="Category ids for which this page will be used."
@@ -142,7 +142,7 @@
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="product"/>
-                                            </categoryFilter>
+                                            </categoryFilterProductPage>
                                             <includesSubCategories
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
@@ -154,11 +154,11 @@
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/renderconditions/or">
-                                                    <granite:rendercondition
+                                                    <categoryPageCondition
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                         pageType="category"/>
-                                                    <granite:rendercondition
+                                                    <productPageCondition
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                         pageType="product"/>


### PR DESCRIPTION
 * fix the commerce tab contents in category page properties


## Related Issue

CIF-2766


## How Has This Been Tested?

Manually, UI test (in Venia)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
