### PR TITLE
CIF-2761: replace model caching 

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/product/ProductImpl.java
@@ -99,8 +99,7 @@ import static com.adobe.cq.wcm.core.components.util.ComponentUtils.ID_SEPARATOR;
 @Model(
     adaptables = SlingHttpServletRequest.class,
     adapters = Product.class,
-    resourceType = ProductImpl.RESOURCE_TYPE,
-    cache = true)
+    resourceType = ProductImpl.RESOURCE_TYPE)
 public class ProductImpl extends DataLayerComponent implements Product {
 
     public static final String RESOURCE_TYPE = "core/cif/components/commerce/product/v1/product";

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productlist/ProductListImpl.java
@@ -65,8 +65,7 @@ import com.day.cq.wcm.api.Page;
 @Model(
     adaptables = SlingHttpServletRequest.class,
     adapters = ProductList.class,
-    resourceType = ProductListImpl.RESOURCE_TYPE,
-    cache = true)
+    resourceType = ProductListImpl.RESOURCE_TYPE)
 public class ProductListImpl extends ProductCollectionImpl implements ProductList {
 
     public static final String RESOURCE_TYPE = "core/cif/components/commerce/productlist/v1/productlist";

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v2/product/ProductImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v2/product/ProductImpl.java
@@ -28,8 +28,7 @@ import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 @Model(
     adaptables = SlingHttpServletRequest.class,
     adapters = Product.class,
-    resourceType = ProductImpl.RESOURCE_TYPE,
-    cache = true)
+    resourceType = ProductImpl.RESOURCE_TYPE)
 public class ProductImpl extends com.adobe.cq.commerce.core.components.internal.models.v1.product.ProductImpl implements Product {
 
     public static final String RESOURCE_TYPE = "core/cif/components/commerce/product/v2/product";

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v2/productlist/ProductListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v2/productlist/ProductListImpl.java
@@ -25,8 +25,7 @@ import com.adobe.cq.commerce.core.components.models.productlist.ProductList;
 @Model(
     adaptables = SlingHttpServletRequest.class,
     adapters = ProductList.class,
-    resourceType = ProductListImpl.RESOURCE_TYPE,
-    cache = true)
+    resourceType = ProductListImpl.RESOURCE_TYPE)
 public class ProductListImpl extends com.adobe.cq.commerce.core.components.internal.models.v1.productlist.ProductListImpl implements
     ProductList {
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImpl.java
@@ -56,7 +56,6 @@ import com.adobe.cq.commerce.core.search.models.SearchOptions;
 import com.adobe.cq.commerce.core.search.models.SearchResultsSet;
 import com.adobe.cq.commerce.core.search.models.Sorter;
 import com.adobe.cq.commerce.core.search.models.SorterKey;
-import com.adobe.cq.commerce.core.search.services.SearchFilterService;
 import com.adobe.cq.commerce.core.search.services.SearchResultsService;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.Aggregation;
@@ -89,7 +88,7 @@ public class SearchResultsServiceImpl implements SearchResultsService {
     private static final String CATEGORY_UID_FILTER = "category_uid";
 
     @Reference
-    private SearchFilterService searchFilterService;
+    private SearchFilterServiceImpl searchFilterService;
     @Reference
     private UrlProvider urlProvider;
 
@@ -178,7 +177,7 @@ public class SearchResultsServiceImpl implements SearchResultsService {
 
         // We will use the search filter service to retrieve all of the potential available filters the commerce system
         // has available for querying against
-        List<FilterAttributeMetadata> availableFilters = searchFilterService.retrieveCurrentlyAvailableCommerceFilters(page);
+        List<FilterAttributeMetadata> availableFilters = searchFilterService.retrieveCurrentlyAvailableCommerceFilters(request, page);
         SorterKey currentSorterKey = prepareSorting(mutableSearchOptions, searchResultsSet);
 
         String productsQueryString = generateProductsQueryString(mutableSearchOptions, availableFilters, productQueryHook,

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/PageMetadataImplTest.java
@@ -76,6 +76,8 @@ public class PageMetadataImplTest {
         "my-store", "enableUIDSupport", "true"));
     private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT = new ComponentsConfiguration(MOCK_CONFIGURATION);
 
+    private final CommerceComponentModelFinder componentModelFinder = new CommerceComponentModelFinder();
+
     @Rule
     public final AemContext context = buildAemContext("/context/jcr-content-breadcrumb.json")
         .<AemContext>afterSetUp(context -> {
@@ -90,9 +92,8 @@ public class PageMetadataImplTest {
             context.registerAdapter(Resource.class, ConfigurationBuilder.class, mockConfigBuilder);
 
             // TODO: CIF-2469
-            CommerceComponentModelFinder commerceModelFinder = new CommerceComponentModelFinder();
-            Whitebox.setInternalState(commerceModelFinder, "modelFactory", context.getService(ModelFactory.class));
-            context.registerService(CommerceComponentModelFinder.class, commerceModelFinder);
+            Whitebox.setInternalState(componentModelFinder, "modelFactory", context.getService(ModelFactory.class));
+            context.registerService(CommerceComponentModelFinder.class, componentModelFinder);
         })
         .build();
 
@@ -134,7 +135,7 @@ public class PageMetadataImplTest {
     public void testPageMetadataModelOnProductPage() throws Exception {
         testPageMetadataModelOnProductPage("/content/venia/us/en/products/product-page");
 
-        Product productModel = context.request().adaptTo(Product.class);
+        Product productModel = componentModelFinder.findProductComponentModel(context.request());
         assertTrue(productModel instanceof com.adobe.cq.commerce.core.components.internal.models.v1.product.ProductImpl);
         assertEquals("MJ01", productModel.getSku()); // This ensures the data is fetched
         assertFalse("The product doesn't have staged data", productModel.isStaged());
@@ -155,7 +156,7 @@ public class PageMetadataImplTest {
 
         // see jcr-content-breadcrumb.json : this product component is configured to be version 2
         // so we test that the adaptation in PageMetadataImpl is done with the right resource type
-        Product productModel = context.request().adaptTo(Product.class);
+        Product productModel = componentModelFinder.findProductComponentModel(context.request());
         assertTrue(productModel instanceof com.adobe.cq.commerce.core.components.internal.models.v2.product.ProductImpl);
         assertEquals("MJ01", productModel.getSku()); // This ensures the data is fetched
         assertTrue("The product has staged data", productModel.isStaged());
@@ -209,7 +210,7 @@ public class PageMetadataImplTest {
     public void testPageMetadataModelOnCategoryPage() throws Exception {
         testPageMetadataModelOnCategoryPage("/content/venia/us/en/products/category-page");
 
-        ProductList productListModel = context.request().adaptTo(ProductList.class);
+        ProductList productListModel = componentModelFinder.findProductListComponentModel(context.request());
         assertTrue(productListModel instanceof com.adobe.cq.commerce.core.components.internal.models.v1.productlist.ProductListImpl);
         assertEquals("Running", productListModel.getTitle()); // This ensures the data is fetched
         assertFalse("The category doesn't have staged data", productListModel.isStaged());
@@ -237,7 +238,7 @@ public class PageMetadataImplTest {
 
         // see jcr-content-breadcrumb.json : this productlist component is configured to be version 2
         // so we test that the adaptation in PageMetadataImpl is done with the right resource type
-        ProductList productListModel = context.request().adaptTo(ProductList.class);
+        ProductList productListModel = componentModelFinder.findProductListComponentModel(context.request());
         assertTrue(productListModel instanceof com.adobe.cq.commerce.core.components.internal.models.v2.productlist.ProductListImpl);
         assertTrue("The category has staged data", productListModel.isStaged());
     }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImplTest.java
@@ -53,7 +53,6 @@ import com.adobe.cq.commerce.core.search.models.SearchAggregation;
 import com.adobe.cq.commerce.core.search.models.SearchAggregationOption;
 import com.adobe.cq.commerce.core.search.models.SearchResultsSet;
 import com.adobe.cq.commerce.core.search.models.Sorter;
-import com.adobe.cq.commerce.core.search.services.SearchFilterService;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.magento.graphql.Aggregation;
 import com.adobe.cq.commerce.magento.graphql.AggregationOption;
@@ -91,7 +90,7 @@ public class SearchResultsServiceImplTest {
     public final AemContext context = newAemContext("/context/jcr-content.json");
 
     @Mock
-    SearchFilterService searchFilterService;
+    SearchFilterServiceImpl searchFilterService;
     @Mock
     MagentoGraphqlClient magentoGraphqlClient;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -152,7 +151,7 @@ public class SearchResultsServiceImplTest {
             new UrlRewrite().setUrl("just-another/category/product")));
         productHits.add(product);
 
-        when(searchFilterService.retrieveCurrentlyAvailableCommerceFilters(any())).thenReturn(Arrays.asList(
+        when(searchFilterService.retrieveCurrentlyAvailableCommerceFilters(any(), any())).thenReturn(Arrays.asList(
             createMatchFilterAttributeMetadata(FILTER_ATTRIBUTE_NAME_CODE),
             createStringEqualFilterAttributeMetadata(FILTER_ATTRIBUTE_COLOR_CODE),
             createRangeFilterAttributeMetadata(FILTER_ATTRIBUTE_PRICE1_CODE),
@@ -175,7 +174,7 @@ public class SearchResultsServiceImplTest {
 
         categoryTree.setUid(new ID("foobar"));
 
-        context.registerService(SearchFilterService.class, searchFilterService);
+        context.registerService(SearchFilterServiceImpl.class, searchFilterService);
         context.registerAdapter(SlingHttpServletRequest.class, MagentoGraphqlClient.class, magentoGraphqlClient);
 
         prepareSearchOptions();
@@ -256,7 +255,7 @@ public class SearchResultsServiceImplTest {
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(magentoGraphqlClient, times(1)).execute(captor.capture());
 
-        verify(searchFilterService, times(1)).retrieveCurrentlyAvailableCommerceFilters(any());
+        verify(searchFilterService, times(1)).retrieveCurrentlyAvailableCommerceFilters(any(), any());
         assertThat(searchResultsSet).isNotNull();
         assertThat(searchResultsSet.getTotalResults()).isEqualTo(0);
         assertThat(searchResultsSet.getAppliedQueryParameters()).containsKeys("search_query");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The change removes model caching and replaces it with a request scoped cache maintained by the `MagentoGraphqlClient` model. It allows components of the same type to be used more than once on a page (in particular product list) while preserving the optimisation done to not query the commerce backend multiple times for the same component.

Existing tests cover this behaviour already.

## Related Issue

CIF-2761

## Motivation and Context

Support multiple Product List components on a single page.

## How Has This Been Tested?

Unit tests, locally manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
