### PR TITLE
CIF-2792: Always add SKU to product url format params

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImpl.java
@@ -255,6 +255,7 @@ public class UrlProviderImpl implements UrlProvider {
                     ProductInterface product = retriever.fetchProduct();
                     if (product != null) {
                         params = new ProductUrlFormat.Params(product);
+                        params.setSku(productIdentifier);
                     } else {
                         LOGGER.debug("Could not generate product page URL for {}.", productIdentifier);
                     }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/services/UrlProviderImplTest.java
@@ -44,6 +44,7 @@ import com.adobe.cq.commerce.core.MockHttpClientBuilderFactory;
 import com.adobe.cq.commerce.core.components.internal.services.urlformats.CategoryPageWithUrlKey;
 import com.adobe.cq.commerce.core.components.internal.services.urlformats.ProductPageWithCategoryAndUrlKey;
 import com.adobe.cq.commerce.core.components.internal.services.urlformats.ProductPageWithSku;
+import com.adobe.cq.commerce.core.components.internal.services.urlformats.ProductPageWithSkuAndUrlKey;
 import com.adobe.cq.commerce.core.components.internal.services.urlformats.ProductPageWithUrlPath;
 import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.core.components.services.urls.CategoryUrlFormat;
@@ -93,6 +94,8 @@ public class UrlProviderImplTest {
 
         Utils.setupHttpResponse("graphql/magento-graphql-product-result.json", httpClient, HttpStatus.SC_OK,
             "{products(filter:{sku:{eq:\"MJ01\"}}");
+        Utils.setupHttpResponse("graphql/magento-graphql-product-result-url-parameters.json", httpClient, HttpStatus.SC_OK,
+            "{products(filter:{sku:{eq:\"MJ03\"}}");
         Utils.setupHttpResponse("graphql/magento-graphql-product-not-found-result.json", httpClient, HttpStatus.SC_OK,
             "{products(filter:{sku:{eq:\"MJ02\"}}");
         Utils.setupHttpResponse("graphql/magento-graphql-product-sku.json", httpClient, HttpStatus.SC_OK,
@@ -222,6 +225,21 @@ public class UrlProviderImplTest {
 
         // not required when only sku is used
         verify(graphqlClient, never()).execute(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testProductUrlWithSKUProductNotFound() {
+        Page page = context.currentPage("/content/product-page");
+        MockOsgi.deactivate(urlProvider, context.bundleContext());
+        MockOsgi.activate(urlProvider, context.bundleContext(), "productPageUrlFormat", ProductPageWithSkuAndUrlKey.PATTERN);
+
+        // Not found, sku set
+        String url = urlProvider.toProductUrl(request, page, "MJ02");
+        assertEquals("/content/product-page.html/MJ02.html", url);
+
+        // found, parameters queried without sku set
+        url = urlProvider.toProductUrl(request, page, "MJ03");
+        assertEquals("/content/product-page.html/MJ03/test-url-key.html", url);
     }
 
     @Test

--- a/bundles/core/src/test/resources/graphql/magento-graphql-product-result-url-parameters.json
+++ b/bundles/core/src/test/resources/graphql/magento-graphql-product-result-url-parameters.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "products": {
+      "items": [
+        {
+          "__typename": "ConfigurableProduct",
+          "url_key": "test-url-key",
+          "url_rewrites": [{
+            "url": "test-url-key"
+          }]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change address a regression introduced with #776 after which the sku is not always available to product url formats. 

## Related Issue

#776 
#875 
CIF-2792

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit Tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
