### PR TITLE
CIF-2811: update frontend-maven-plugin

### DIFF
--- a/examples/ui.frontend/pom.xml
+++ b/examples/ui.frontend/pom.xml
@@ -46,9 +46,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.9.1</version>
                 <configuration>
-                    <nodeVersion>v12.14.1</nodeVersion>
                     <installDirectory>../../frontend-maven-plugin</installDirectory>
                     <workingDirectory>${basedir}</workingDirectory>
                 </configuration>

--- a/extensions/product-recs/content/pom.xml
+++ b/extensions/product-recs/content/pom.xml
@@ -98,9 +98,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.9.1</version>
                 <configuration>
-                    <nodeVersion>v12.14.1</nodeVersion>
                     <installDirectory>../../../frontend-maven-plugin</installDirectory>
                     <workingDirectory>${basedir}</workingDirectory>
                 </configuration>

--- a/extensions/product-recs/react-components/pom.xml
+++ b/extensions/product-recs/react-components/pom.xml
@@ -55,9 +55,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.9.1</version>
                 <configuration>
-                    <nodeVersion>v12.14.1</nodeVersion>
                     <installDirectory>../../../frontend-maven-plugin</installDirectory>
                 </configuration>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -703,6 +703,15 @@
                         <source>8</source>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>1.12.1</version>
+                    <configuration>
+                        <nodeVersion>v12.14.1</nodeVersion>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/react-components/pom.xml
+++ b/react-components/pom.xml
@@ -55,9 +55,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.9.1</version>
                 <configuration>
-                    <nodeVersion>v12.14.1</nodeVersion>
                     <installDirectory>../frontend-maven-plugin</installDirectory>
                 </configuration>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -103,9 +103,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.9.1</version>
                 <configuration>
-                    <nodeVersion>v12.14.1</nodeVersion>
                     <installDirectory>../frontend-maven-plugin</installDirectory>
                     <workingDirectory>${basedir}</workingDirectory>
                 </configuration>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With this change we move parts of frontend-maven-plugin configuration to the parent module to reduce duplication. We also update the version to the latest release.

## Related Issue

CIF-2811
https://github.com/eirslett/frontend-maven-plugin/pull/970

## Motivation and Context

Support builds on Apple Silicon with node versions older than 16

## How Has This Been Tested?

Build locally, CI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
