### PR TITLE
CIF-2757 - Add tracking annotations for product and category filters in page properties

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -113,7 +113,7 @@
                                                 selectionId="uidAndUrlPath"
                                                 showLink="{Boolean}true"
                                                 trackingElement="category filter"
-                                                trackingFeature="aem:cif:specificcatalogtemplate">
+                                                trackingFeature="aem:cif:specificcategorytemplate">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>
@@ -142,7 +142,7 @@
                                                 enablePreviewDateFilter="{Boolean}true"
                                                 showLink="{Boolean}true"
                                                 trackingElement="product filter"
-                                                trackingFeature="aem:cif:specificcatalogtemplate">
+                                                trackingFeature="aem:cif:specificproducttemplate">
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -111,7 +111,9 @@
                                                 multiple="{Boolean}true"
                                                 name="./selectorFilter"
                                                 selectionId="uidAndUrlPath"
-                                                showLink="{Boolean}true">
+                                                showLink="{Boolean}true"
+                                                trackingElement="category filter"
+                                                trackingFeature="aem:cif:specificcatalogtemplate">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>
@@ -138,7 +140,9 @@
                                                 rootPath="/var/commerce/products"
                                                 selectionId="slug"
                                                 enablePreviewDateFilter="{Boolean}true"
-                                                showLink="{Boolean}true">
+                                                showLink="{Boolean}true"
+                                                trackingElement="product filter"
+                                                trackingFeature="aem:cif:specificcatalogtemplate">
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -124,7 +124,7 @@
                                                 enablePreviewDateFilter="{Boolean}true"
                                                 showLink="{Boolean}true"
                                                 trackingElement="product filter"
-                                                trackingFeature="aem:cif:specificcatalogtemplate">
+                                                trackingFeature="aem:cif:specificproducttemplate">
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
@@ -139,7 +139,7 @@
                                                 selectionId="urlPath"
                                                 showLink="{Boolean}true"
                                                 trackingElement="category filter"
-                                                trackingFeature="aem:cif:specificcatalogtemplate">
+                                                trackingFeature="aem:cif:specificcategorytemplate">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>
@@ -153,7 +153,7 @@
                                                 selectionId="urlPath"
                                                 showLink="{Boolean}true"
                                                 trackingElement="category filter"
-                                                trackingFeature="aem:cif:specificcatalogtemplate">
+                                                trackingFeature="aem:cif:specificproducttemplate">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="product"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -122,7 +122,9 @@
                                                 rootPath="/var/commerce/products"
                                                 selectionId="slug"
                                                 enablePreviewDateFilter="{Boolean}true"
-                                                showLink="{Boolean}true">
+                                                showLink="{Boolean}true"
+                                                trackingElement="product filter"
+                                                trackingFeature="aem:cif:specificcatalogtemplate">
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
@@ -135,7 +137,9 @@
                                                 multiple="{Boolean}true"
                                                 name="./selectorFilter"
                                                 selectionId="urlPath"
-                                                showLink="{Boolean}true">
+                                                showLink="{Boolean}true"
+                                                trackingElement="category filter"
+                                                trackingFeature="aem:cif:specificcatalogtemplate">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="category"/>
@@ -147,7 +151,9 @@
                                                 multiple="{Boolean}true"
                                                 name="./useForCategories"
                                                 selectionId="urlPath"
-                                                showLink="{Boolean}true">
+                                                showLink="{Boolean}true"
+                                                trackingElement="category filter"
+                                                trackingFeature="aem:cif:specificcatalogtemplate">
                                                 <granite:rendercondition jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                     pageType="product"/>


### PR DESCRIPTION
## Description

* Add tracking annotations to product and category filters for specific product and category pages

## How Has This Been Tested?

* E2E tests added via https://github.com/adobe/aem-cif-guides-venia/pull/275

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
