### PR TITLE
releng - Fix jest jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,9 +165,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
-      - run:
           name: Provision
           command: |
             node -v
@@ -190,9 +187,6 @@ jobs:
       - image: cimg/node:lts-browsers
     steps:
       - checkout
-      - run:
-          name: Update permissions
-          command: sudo chown -R circleci /usr/local/lib/node_modules
       - run:
           name: Provision (Core)
           command: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Nightly jobs started to fail because `cimg/node:lts-browsers` CircleCI Docker images don't need permission fixes for npm anymore.
* The OpenJDK images still need it though.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
