### PR TITLE
CIF-2866 - Alternative category page takes over the whole navigation

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
@@ -180,7 +180,7 @@ public class NavigationImpl implements Navigation {
     }
 
     private void expandCatalogRoot(Page catalogPage, List<NavigationItem> pages) {
-        Page categoryPage = SiteNavigation.getCategoryPage(currentPage);
+        Page categoryPage = SiteNavigation.getCategoryPage(catalogPage);
         if (categoryPage == null) {
             return;
         }


### PR DESCRIPTION
Fix navigation rendering with multiple catalog pages.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
CIF-2866

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->



## How Has This Been Tested?

Manually, JUnit.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
