### PR TITLE
CIF-2127 - Enable showLink options for all product and categoryfields

### DIFF
--- a/extensions/product-recs/content/src/main/content/jcr_root/apps/core/cif/extensions/product-recs/components/productrecommendations/v1/productrecommendations/_cq_dialog/.content.xml
+++ b/extensions/product-recs/content/src/main/content/jcr_root/apps/core/cif/extensions/product-recs/components/productrecommendations/v1/productrecommendations/_cq_dialog/.content.xml
@@ -76,6 +76,7 @@
                                             multiple="{Boolean}true"
                                             fieldLabel="Included categories"
                                             selectionId="slug"
+                                            showLink="{Boolean}true"
                                             name="./includedCategories" />
                                     <useFilter
                                             jcr:primaryType="nt:unstructured"
@@ -151,6 +152,7 @@
                                             fieldLabel="Excluded categories"
                                             multiple="{Boolean}true"
                                             selectionId="slug"
+                                            showLink="{Boolean}true"
                                             name="./excludedCategories" />
                                     <useFilter
                                             jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/categorycarousel/v1/categorycarousel/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/categorycarousel/v1/categorycarousel/_cq_dialog/.content.xml
@@ -29,6 +29,7 @@
                                     sling:resourceType="commerce/gui/components/common/cifcategoryfield" 
                                     fieldLabel="Category" 
                                     multiple="{Boolean}false" 
+                                    showLink="{Boolean}true"
                                     name="./categoryId" />
                                 <asset jcr:primaryType="nt:unstructured" 
                                     sling:resourceType="granite/ui/components/coral/foundation/form/pathfield" 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/featuredcategorylist/v1/featuredcategorylist/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/featuredcategorylist/v1/featuredcategorylist/_cq_dialog/.content.xml
@@ -44,6 +44,7 @@
                                     sling:resourceType="commerce/gui/components/common/cifcategoryfield" 
                                     fieldLabel="Category" 
                                     multiple="{Boolean}false" 
+                                    showLink="{Boolean}true"
                                     name="./categoryId" />
                                 <asset jcr:primaryType="nt:unstructured" 
                                     sling:resourceType="granite/ui/components/coral/foundation/form/pathfield" 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/_cq_dialog/.content.xml
@@ -17,6 +17,7 @@
                         sling:resourceType="commerce/gui/components/common/cifproductfield"
                         fieldDescription="The product that should be displayed by the product detail component."
                         fieldLabel="Manual Product Selection"
+                        showLink="{Boolean}true"
                         name="./selection"
                         selectionId="sku"/>
                     <well

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/_cq_dialog/.content.xml
@@ -68,6 +68,7 @@
                                     sling:resourceType="commerce/gui/components/common/cifproductfield"
                                     fieldLabel="Product"
                                     name="./product"
+                                    showLink="{Boolean}true"
                                     selectionId="combinedSku" />
                             </products>
                         </items>
@@ -89,6 +90,7 @@
                                         multiple="{Boolean}false"
                                         fieldDescription="The category of the products to be displayed."
                                         fieldLabel="Category"
+                                        showLink="{Boolean}true"
                                         name="./category"/>
                                     <productCount jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v2/productlist/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productlist/v2/productlist/_cq_dialog/.content.xml
@@ -20,6 +20,7 @@
                         sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                         fieldDescription="The category that should be displayed by the product list component."
                         fieldLabel="Manual Category Selection"
+                        showLink="{Boolean}true"
                         name="./category"/>
                     <well
                         jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/_cq_dialog/.content.xml
@@ -35,6 +35,7 @@
                                                 fieldDescription="The product or product variant displayed by the teaser"
                                                 fieldLabel="Select Product"
                                                 name="./selection"
+                                                showLink="{Boolean}true"
                                                 selectionId="combinedSku"/>
                                             <call-to-action
                                                 jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/relatedproducts/v1/relatedproducts/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/relatedproducts/v1/relatedproducts/_cq_dialog/.content.xml
@@ -21,6 +21,7 @@
                         fieldDescription="Base product used to display related products. If empty, the component will fetch the product based on the selector of the URL." 
                         fieldLabel="Base product - Leave empty to use the current product of the generic product page." 
                         name="./product" 
+                        showLink="{Boolean}true"
                         selectionId="sku" />
                     <relationType jcr:primaryType="nt:unstructured" 
                         sling:resourceType="granite/ui/components/coral/foundation/form/select"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/button/v1/button/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/button/v1/button/_cq_dialog/.content.xml
@@ -104,6 +104,7 @@
                                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                                 fieldLabel="Product"
                                                                 name="./productSlug"
+                                                                showLink="{Boolean}true"
                                                                 selectionId="slug"/>
                                                         </items>
                                                     </well>
@@ -125,6 +126,7 @@
                                                                 jcr:primaryType="nt:unstructured"
                                                                 sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                                                                 fieldLabel="Category"
+                                                                showLink="{Boolean}true"
                                                                 name="./categoryId" />
                                                         </items>
                                                     </well>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/button/v2/button/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/button/v2/button/_cq_dialog/.content.xml
@@ -92,6 +92,7 @@
                                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                                 fieldLabel="Product"
                                                                 name="./productSku"
+                                                                showLink="{Boolean}true"
                                                                 selectionId="sku"/>
                                                         </items>
                                                     </well>
@@ -114,6 +115,7 @@
                                                                 jcr:primaryType="nt:unstructured"
                                                                 sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                                                                 fieldLabel="Category"
+                                                                showLink="{Boolean}true"
                                                                 name="./categoryId" />
                                                         </items>
                                                     </well>

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -102,6 +102,7 @@
                                                             fieldLabel="Product"
                                                             name="productSlug"
                                                             required="{Boolean}false"
+                                                            showLink="{Boolean}true"
                                                             selectionId="slug">
                                                             <granite:data
                                                                 jcr:primaryType="nt:unstructured"
@@ -113,6 +114,7 @@
                                                             sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                                                             fieldLabel="Category"
                                                             name="categoryId"
+                                                            showLink="{Boolean}true"
                                                             required="{Boolean}false">
                                                             <granite:data
                                                                 jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -102,6 +102,7 @@
                                                             fieldLabel="Product"
                                                             name="productSku"
                                                             required="{Boolean}false"
+                                                            showLink="{Boolean}true"
                                                             selectionId="sku">
                                                             <granite:data
                                                                 jcr:primaryType="nt:unstructured"
@@ -113,6 +114,7 @@
                                                             sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                                                             fieldLabel="Category"
                                                             name="categoryId"
+                                                            showLink="{Boolean}true"
                                                             required="{Boolean}false">
                                                             <granite:data
                                                                 jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/catalogpage/v1/catalogpage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/catalogpage/v1/catalogpage/_cq_dialog/.content.xml
@@ -69,6 +69,7 @@
                                                 fieldLabel="Root Category Identifier"
                                                 name="./magentoRootCategoryId"
                                                 renderReadOnly="{Boolean}true"
+                                                showLink="{Boolean}true"
                                                 translateOptions="{Boolean}false">
                                                 <granite:data jcr:primaryType="nt:unstructured"
                                                     cq-msm-lockable="magentoRootCategoryId" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Enabled the `showLink` option for all product and category fields. This will now display a reference button (single selection) or a reference table (multi selection) with links to the selected products and categories.

## How Has This Been Tested?

* Manually tested that buttons/tables are displayed for all the updated components.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
