### PR TITLE
CIF-2884 - Commerce teaser dialog clientlib regressions

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v3/teaser/clientlib/editor/js/teaser.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/content/teaser/v3/teaser/clientlib/editor/js/teaser.js
@@ -72,6 +72,20 @@ class TeaserConfig {
     }
 
     setFieldsDisabled(disabled) {
+        this.$(document.querySelector(TeaserConfig.selectors.actionsMultifieldSelector))
+            .adaptTo('foundation-field')
+            .setDisabled(disabled);
+
+        document.querySelectorAll(TeaserConfig.selectors.pageFieldSelector).forEach(el => {
+            this.$(el)
+                .adaptTo('foundation-field')
+                .setDisabled(disabled);
+        });
+        document.querySelectorAll(TeaserConfig.selectors.targetFieldSelector).forEach(el => {
+            this.$(el)
+                .adaptTo('foundation-field')
+                .setDisabled(disabled);
+        });
         document.querySelectorAll(TeaserConfig.selectors.categoryFieldSelector).forEach(catEl => {
             this.$(catEl)
                 .adaptTo('foundation-field')
@@ -79,6 +93,11 @@ class TeaserConfig {
         });
         document.querySelectorAll(TeaserConfig.selectors.productFieldSelector).forEach(prodEl => {
             this.$(prodEl)
+                .adaptTo('foundation-field')
+                .setDisabled(disabled);
+        });
+        document.querySelectorAll(TeaserConfig.selectors.titleFieldSelector).forEach(el => {
+            this.$(el)
                 .adaptTo('foundation-field')
                 .setDisabled(disabled);
         });
@@ -143,8 +162,10 @@ class TeaserConfig {
 TeaserConfig.selectors = {
     dialogContentSelector: '[data-cmp-is="commerceteaser-editor"].cmp-teaser__editor',
     pageFieldSelector: '[data-cmp-teaser-v1-dialog-edit-hook="actionLink"]',
+    targetFieldSelector: '[data-cmp-teaser-v2-dialog-edit-hook="actionTarget"]',
     productFieldSelector: '[data-cmp-teaser-v1-dialog-edit-hook="actionProduct"]',
     categoryFieldSelector: '[data-cmp-teaser-v1-dialog-edit-hook="actionCategory"]',
+    titleFieldSelector: '[data-cmp-teaser-v2-dialog-edit-hook="actionTitle"]',
     actionsMultifieldSelector: '.cmp-teaser__editor-multifield_actions',
     actionsMultifieldItemSelector: 'coral-multifield-item',
     actionsEnabledCheckboxSelector: 'coral-checkbox[name="./actionsEnabled"]'

--- a/ui.apps/test/components/content/teaser/teaserConfigTest.js
+++ b/ui.apps/test/components/content/teaser/teaserConfigTest.js
@@ -206,6 +206,24 @@ import jQuery from '../../../clientlibs/common/jQueryMockForTest';
                                                         </coral-taglist>
                                                         <input class="foundation-field-related" type="hidden"
                                                                name="./actions/item0/link@Delete"></foundation-autocomplete>
+                                                </div>
+                                                <div class="coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
+                                                    <coral-checkbox class="cmp-teaser__editor-actionField-linkTarget coral-Form-field _coral-Checkbox" data-cmp-teaser-v2-dialog-edit-hook="actionTarget" name="./actions/item0/./linkTarget" value="_blank" labelledby="description_866fc36e-46a1-4923-9f15-15a46e861631" data-foundation-validation="" data-validation="">
+                                                        <input type="checkbox" handle="input" class=" _coral-Checkbox-input" id="coral-id-577" aria-labelledby="description_866fc36e-46a1-4923-9f15-15a46e861631" name="./actions/item0/./linkTarget" value="_blank">
+                                                        <span class=" _coral-Checkbox-box" handle="checkbox"></span>
+                                                        <label class=" _coral-Checkbox-label" handle="labelWrapper" for="coral-id-577" style="margin: 0px;">
+                                                            <span class=" u-coral-screenReaderOnly" handle="screenReaderOnly" hidden="">Select</span>
+                                                            <coral-checkbox-label></coral-checkbox-label>
+                                                        </label>
+                                                    </coral-checkbox>
+                                                    <input class="foundation-field-related" type="hidden" name="./actions/item0/./linkTarget@Delete">
+                                                    <input class="foundation-field-related" type="hidden" value="_self" name="./actions/item0/./linkTarget@DefaultValue">
+                                                    <input class="foundation-field-related" type="hidden" value="true" name="./actions/item0/./linkTarget@UseDefaultWhenMissing">
+                                                    <coral-icon class="coral-Form-fieldinfo _coral-Icon _coral-Icon--sizeS" icon="infoCircle" tabindex="0" aria-describedby="description_866fc36e-46a1-4923-9f15-15a46e861631" alt="description" role="img" aria-label="description" size="S"></coral-icon>
+                                                    <coral-tooltip target="_prev" placement="right" id="description_866fc36e-46a1-4923-9f15-15a46e861631" x-placement="left" x-out-of-boundaries="" class="_coral-Overlay _coral-Tooltip _coral-Tooltip--default _coral-Tooltip--left" role="tooltip" tabindex="-1" variant="default">                                                                
+                                                        <span class=" _coral-Tooltip-tip" handle="tip"></span>
+                                                        <coral-tooltip-content class="_coral-Tooltip-label">If checked the link will be opened in a new browser tab.</coral-tooltip-content>
+                                                    </coral-tooltip>
                                                 </div>                                            
                                                 <div class="coral-Form-fieldwrapper">
                                                     <label class="coral-Form-fieldlabel">Product</label>
@@ -334,13 +352,13 @@ import jQuery from '../../../clientlibs/common/jQueryMockForTest';
                                                     </foundation-autocomplete>
                                                 </div>
                                                 <div class="coral-Form-fieldwrapper">
-                                                    <label class="coral-Form-fieldlabel">Link Text
-                                                    *</label>
-                                                        <input
-                                                            class="coral-Form-field cmp-teaser__editor-actionField coral3-Textfield"
-                                                            data-cmp-teaser-v1-dialog-edit-hook="actionTitle" data-foundation-validation=""
-                                                            data-validation="" is="coral-textfield" name="./actions/item0/text"
-                                                            placeholder="Text" type="text" value="">
+                                                    <label class="coral-Form-fieldlabel">Link Text *</label>
+                                                    <input
+                                                        class="coral-Form-field cmp-teaser__editor-actionField coral3-Textfield"
+                                                        data-cmp-teaser-v1-dialog-edit-hook="actionTitle" data-foundation-validation=""                                                        
+                                                        data-validation="" is="coral-textfield" 
+                                                        data-cmp-teaser-v2-dialog-edit-hook="actionTitle" name="./actions/item0/text"
+                                                        placeholder="Text" type="text" value="">
                                                 </div>
                                             </div>
                                         </coral-multifield-item-content>


### PR DESCRIPTION
Fixing the enabling / disabling of the action fields depending on the actions checkbox status.

## Related Issue

CIF-2884


## How Has This Been Tested?

Manually, UI tests.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
