### PR TITLE
releng - Fallback to legacy peer dependency check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
           name: Provision (Extension)
           command: |
             npm install
-            npm link @adobe/aem-core-cif-react-components
+            npm link @adobe/aem-core-cif-react-components --legacy-peer-deps
           working_directory: ./extensions/product-recs/react-components
       - run:
           name: Run Unit Tests (Jest)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* With npm 7+ and the new package-lock.json format, peer dependency checks got stricter and are enforced.
* Unfortunately there is an issue with peregrine 11 which requires react 17 and apollo 3.1.x, while apollo 3.1.5 (latest) only works with react 16.
* Since these peer dependencies cannot easily be fixed, we can force npm to fallback to the old peer dependency behaviour to fix the failing CircleCI build.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
