### PR TITLE
CIF-2919: allow to enforce POST requests for customAttributeMetadata query

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/search/internal/services/SearchFilterServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/search/internal/services/SearchFilterServiceImplTest.java
@@ -25,7 +25,7 @@ import org.apache.http.osgi.services.HttpClientBuilderFactory;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.osgi.MockOsgi;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +37,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.adobe.cq.commerce.core.MockHttpClientBuilderFactory;
 import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.core.search.models.FilterAttributeMetadata;
+import com.adobe.cq.commerce.core.testing.GraphqlQueryMatcher;
 import com.adobe.cq.commerce.core.testing.Utils;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
@@ -47,33 +48,29 @@ import com.day.cq.wcm.api.Page;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
-import io.wcm.testing.mock.aem.junit.AemContextCallback;
 
+import static com.adobe.cq.commerce.core.testing.TestContext.buildAemContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SearchFilterServiceImplTest {
 
     @Rule
-    public final AemContext context = createContext("/context/jcr-content.json");
+    public final AemContext context = buildAemContext("/context/jcr-content.json")
+        .<AemContext>afterSetUp(context -> {
+            context.registerAdapter(Resource.class, ComponentsConfiguration.class,
+                (Function<Resource, ComponentsConfiguration>) input -> MOCK_CONFIGURATION_OBJECT);
+        })
+        .build();
 
     private static final ValueMap MOCK_CONFIGURATION = new ValueMapDecorator(ImmutableMap.of("cq:graphqlClient", "default", "magentoStore",
         "my-store", "enableUIDSupport", "true"));
     private static final ComponentsConfiguration MOCK_CONFIGURATION_OBJECT = new ComponentsConfiguration(MOCK_CONFIGURATION);
-
-    private static AemContext createContext(String contentPath) {
-        return new AemContext(
-            (AemContextCallback) context -> {
-                // Load page structure
-                context.load().json(contentPath, "/content");
-                context.registerAdapter(Resource.class, ComponentsConfiguration.class,
-                    (Function<Resource, ComponentsConfiguration>) input -> MOCK_CONFIGURATION_OBJECT);
-            },
-            ResourceResolverType.JCR_MOCK);
-    }
 
     private static final String PAGE = "/content/pageA";
 
@@ -91,7 +88,7 @@ public class SearchFilterServiceImplTest {
         context.registerService(HttpClientBuilderFactory.class, new MockHttpClientBuilderFactory(httpClient));
 
         graphqlClient = new GraphqlClientImpl();
-        context.registerInjectActivateService(graphqlClient, "httpMethod", "POST");
+        context.registerInjectActivateService(graphqlClient, "httpMethod", "GET");
 
         Utils.setupHttpResponse("graphql/magento-graphql-introspection-result.json", httpClient, HttpStatus.SC_OK, "{__type");
         Utils.setupHttpResponse("graphql/magento-graphql-attributes-result.json", httpClient, HttpStatus.SC_OK, "{customAttributeMetadata");
@@ -131,6 +128,23 @@ public class SearchFilterServiceImplTest {
         assertThat(newAttr.getFilterInputType()).isEqualTo("FilterEqualTypeInput");
         assertThat(newAttr.getAttributeType()).isEqualTo("Int");
         assertThat(newAttr.getAttributeInputType()).isEqualTo("boolean");
+    }
+
+    @Test
+    public void testRetrieveMetadataEnforcedPost() throws IOException {
+        context.registerAdapter(Resource.class, GraphqlClient.class, (Function<Resource, GraphqlClient>) input -> input.getValueMap().get(
+            "cq:graphqlClient") != null ? graphqlClient : null);
+
+        MockOsgi.deactivate(searchFilterServiceUnderTest, context.bundleContext());
+        MockOsgi.activate(searchFilterServiceUnderTest, context.bundleContext(), "enforcePost", Boolean.TRUE);
+
+        final List<FilterAttributeMetadata> filterAttributeMetadata = searchFilterServiceUnderTest
+            .retrieveCurrentlyAvailableCommerceFilters(page);
+
+        assertThat(filterAttributeMetadata).hasSize(29);
+
+        verify(httpClient).execute(argThat(new GraphqlQueryMatcher("{__type", "get")));
+        verify(httpClient).execute(argThat(new GraphqlQueryMatcher("{customAttributeMetadata", "post")));
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/testing/GraphqlQueryMatcher.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/testing/GraphqlQueryMatcher.java
@@ -1,0 +1,86 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.commerce.core.testing;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.mockito.ArgumentMatcher;
+
+import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
+import com.google.gson.Gson;
+
+/**
+ * Matcher class used to match a GraphQL query. This is used to properly mock GraphQL responses.
+ */
+public class GraphqlQueryMatcher extends ArgumentMatcher<HttpUriRequest> {
+
+    private String contains;
+    private String method;
+
+    public GraphqlQueryMatcher(String contains) {
+        this(contains, null);
+    }
+
+    public GraphqlQueryMatcher(String contains, String method) {
+        this.contains = contains;
+        this.method = method;
+    }
+
+    @Override
+    public boolean matches(Object obj) {
+        if (!(obj instanceof HttpUriRequest)) {
+            return false;
+        }
+
+        HttpUriRequest httpUriRequest = (HttpUriRequest) obj;
+
+        if (method != null) {
+            if (!httpUriRequest.getMethod().equalsIgnoreCase(method)) {
+                return false;
+            }
+        }
+
+        if (httpUriRequest instanceof HttpEntityEnclosingRequest) {
+            // GraphQL query is in POST body
+            HttpEntityEnclosingRequest httpEntityEnclosingRequest = (HttpEntityEnclosingRequest) httpUriRequest;
+            try {
+                String body = IOUtils.toString(httpEntityEnclosingRequest.getEntity().getContent(), StandardCharsets.UTF_8);
+                Gson gson = new Gson();
+                GraphqlRequest graphqlRequest = gson.fromJson(body, GraphqlRequest.class);
+                return graphqlRequest.getQuery().contains(contains);
+            } catch (Exception e) {
+                return false;
+            }
+        } else {
+            // GraphQL query is in the URL 'query' parameter
+            HttpUriRequest req = (HttpUriRequest) obj;
+            String uri = null;
+            try {
+                uri = URLDecoder.decode(req.getURI().toString(), StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                return false;
+            }
+            String graphqlQuery = uri.substring(uri.indexOf("?query=") + 7);
+            return graphqlQuery.contains(contains);
+        }
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With catalogs that have a lot of custom product attributes the customAttributeMetadata query executed by the `SearchFilterServiceImpl` for Product Lists and Search Results may exceed the query parameter limit of http GET requests. Using POSTs for the GraphqlClient in question will resolve the issue but is not recommended as it by-passes any CDN caching that may be involved. 

With this change we allow the CIF Search Filter Service to be configured to enforce POST only for the customAttributeMetadata query. The option is per default disabled. If enabled we recommend to cache the response by configuring the GraphqlClient caching accordingly. 

## Related Issue

CIF-2919

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
