### PR TITLE
CIF-2903 - Add login token to client-side price fetching

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -58,6 +58,11 @@ class CommerceGraphqlApi {
             params.headers['Store'] = this.storeView;
         }
 
+        const loginToken = this._getLoginToken();
+        if (loginToken) {
+            params.headers['Authorization'] = `Bearer ${loginToken}`;
+        }
+
         let url = this.endpoint;
         if (params.method === 'POST') {
             // For un-cached POST request, add query to body
@@ -76,6 +81,27 @@ class CommerceGraphqlApi {
         }
 
         return response;
+    }
+
+    /**
+     * Retrieves the login token from local storage as it is stored by Peregrine.
+     *
+     * @returns {string} login token or null if not logged in.
+     */
+    _getLoginToken() {
+        const key = 'M2_VENIA_BROWSER_PERSISTENCE__signin_token';
+        let token = null;
+
+        try {
+            token = JSON.parse(localStorage.getItem(key));
+        } catch (e) {
+            console.error(`Login token at ${key} is not valid JSON.`);
+        }
+
+        if (token && token.value) {
+            return token.value.replace(/"/g, '');
+        }
+        return null;
     }
 
     /**

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/clientlibs/common/js/CommerceGraphqlApi.js
@@ -90,18 +90,42 @@ class CommerceGraphqlApi {
      */
     _getLoginToken() {
         const key = 'M2_VENIA_BROWSER_PERSISTENCE__signin_token';
-        let token = null;
+        let token = this._checkCookie('cif.userToken') ? this._cookieValue('cif.userToken') : '';
 
         try {
-            token = JSON.parse(localStorage.getItem(key));
+            let lsToken = JSON.parse(localStorage.getItem(key));
+            if (lsToken && lsToken.value) {
+                const timestamp = new Date().getTime();
+                if (timestamp - lsToken.timeStored < lsToken.ttl * 1000) {
+                    token = lsToken.value.replace(/"/g, '');
+                }
+            }
         } catch (e) {
             console.error(`Login token at ${key} is not valid JSON.`);
         }
 
-        if (token && token.value) {
-            return token.value.replace(/"/g, '');
-        }
-        return null;
+        return token;
+    }
+
+    /**
+     * Checks if a cookie with the given name exists.
+     *
+     * @param {string} cookieName
+     * @returns {boolean} true if the cookie exists, false otherwise.
+     */
+    _checkCookie(cookieName) {
+        return document.cookie.split(';').filter(item => item.trim().startsWith(`${cookieName}=`)).length > 0;
+    }
+
+    /**
+     * Returns the value of the cookie with the given name.
+     *
+     * @param {string} cookieName
+     * @returns {string} value of the cookie or empty string if the cookie does not exist.
+     */
+    _cookieValue(cookieName) {
+        let b = document.cookie.match(`(^|[^;]+)\\s*${cookieName}\\s*=\\s*([^;]+)`);
+        return b ? b.pop() : '';
     }
 
     /**

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -40,6 +40,7 @@ describe('CommerceGraphqlApi', () => {
             headers: JSON.parse(httpHeaders)
         });
         window.localStorage.clear();
+        document.cookie = '';
     });
 
     afterEach(() => {
@@ -93,23 +94,38 @@ describe('CommerceGraphqlApi', () => {
         });
     });
 
-    it('passes the authorization header', () => {
+    it('passes the authorization header (from localStorage)', () => {
         const mockResult = { result: 'my-result' };
         fetchSpy.resolves(mockResult);
 
         window.localStorage.setItem(
             'M2_VENIA_BROWSER_PERSISTENCE__signin_token',
-            `{"value":"\\\"my-test-login-token\\\"","timeStored":1655983654091,"ttl":3600}`
+            `{"value":"\\\"my-ls-login-token\\\"","timeStored":${new Date().getTime()},"ttl":3600}`
         );
 
         let query = 'my-sample-query';
 
-        return graphqlApi._fetchGraphql(query, true).then(res => {
+        return graphqlApi._fetchGraphql(query, true).then(_ => {
             assert.isTrue(fetchSpy.calledOnce);
             let options = fetchSpy.firstCall.args[1];
-            console.log(options.headers);
 
-            assert.include(options.headers, { Authorization: 'Bearer my-test-login-token' });
+            assert.include(options.headers, { Authorization: 'Bearer my-ls-login-token' });
+        });
+    });
+
+    it('passes the authorization header (from cookie)', () => {
+        const mockResult = { result: 'my-result' };
+        fetchSpy.resolves(mockResult);
+
+        document.cookie = 'cif.userToken=my-cookie-login-token';
+
+        let query = 'my-sample-query';
+
+        return graphqlApi._fetchGraphql(query, true).then(_ => {
+            assert.isTrue(fetchSpy.calledOnce);
+            let options = fetchSpy.firstCall.args[1];
+
+            assert.include(options.headers, { Authorization: 'Bearer my-cookie-login-token' });
         });
     });
 

--- a/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
+++ b/ui.apps/test/clientlibs/common/commerceGraphqlApiTest.js
@@ -39,6 +39,7 @@ describe('CommerceGraphqlApi', () => {
             graphqlMethod: 'GET',
             headers: JSON.parse(httpHeaders)
         });
+        window.localStorage.clear();
     });
 
     afterEach(() => {
@@ -89,6 +90,26 @@ describe('CommerceGraphqlApi', () => {
             let options = fetchSpy.firstCall.args[1];
 
             assert.include(options.headers, { Store: 'my-special-store' });
+        });
+    });
+
+    it('passes the authorization header', () => {
+        const mockResult = { result: 'my-result' };
+        fetchSpy.resolves(mockResult);
+
+        window.localStorage.setItem(
+            'M2_VENIA_BROWSER_PERSISTENCE__signin_token',
+            `{"value":"\\\"my-test-login-token\\\"","timeStored":1655983654091,"ttl":3600}`
+        );
+
+        let query = 'my-sample-query';
+
+        return graphqlApi._fetchGraphql(query, true).then(res => {
+            assert.isTrue(fetchSpy.calledOnce);
+            let options = fetchSpy.firstCall.args[1];
+            console.log(options.headers);
+
+            assert.include(options.headers, { Authorization: 'Bearer my-test-login-token' });
         });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Client-side GraphQL requests made via `CommerceGraphqlApi` (like client-side price fetching) now send the user token as `Authorization` header.
* This works with both the old `cif.userToken` cookie as well as the token set by Peregrine in local storage.
* Added unit tests for both cases.
* Fixes #914

## How Has This Been Tested?

* Updated unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
