### PR TITLE
CIF-2924: remove category_uid parameter in pagination when applicable

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/search/internal/services/SearchResultsServiceImplTest.java
@@ -334,6 +334,7 @@ public class SearchResultsServiceImplTest {
         SearchAggregation aggregation = aggregations.get(0);
         assertThat(getFilterMapsOfAllOptions(aggregation, filterMapFilter)).isEmpty();
         assertThat(aggregation.getRemoveFilterMap()).doesNotContainKey("category_uid");
+        assertThat(resultsSet.getAppliedQueryParameters()).doesNotContainKey("category_uid");
 
         // test with category_uid filter
         searchOptions.setCategoryUid("foobar");
@@ -343,6 +344,7 @@ public class SearchResultsServiceImplTest {
         aggregation = aggregations.get(0);
         assertThat(getFilterMapsOfAllOptions(aggregation, filterMapFilter).count()).isEqualTo(2);
         assertThat(aggregation.getRemoveFilterMap()).containsEntry("category_uid", "foobar");
+        assertThat(resultsSet.getAppliedQueryParameters()).containsEntry("category_uid", "foobar");
 
         // test with category_uid filter from request
         MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) context.request().getRequestPathInfo();
@@ -353,6 +355,7 @@ public class SearchResultsServiceImplTest {
         aggregation = aggregations.get(0);
         assertThat(getFilterMapsOfAllOptions(aggregation, filterMapFilter)).isEmpty();
         assertThat(aggregation.getRemoveFilterMap()).doesNotContainKey("category_uid");
+        assertThat(resultsSet.getAppliedQueryParameters()).doesNotContainKey("category_uid");
     }
 
     private static FilterAttributeMetadata createStringEqualFilterAttributeMetadata(String attributeCode) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The category_uid parameter got introduced when we switched from using the category id to uid in the product list. We removed it incrementally already in some places (applying facets, removing facets, facet navigation). With this change we removed it also from the pagination. 

## Related Issue

CIF-2924

## Motivation and Context

The category_uid parameter is not necessary as for product lists the category_uid can always be obtained from the request url. Adding the parameter may affect the dispatcher cache ratio as it leads to different, eventually uncached urls for the same page.

## How Has This Been Tested?

Unit tests, locally using Venia

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
