### PR TITLE
CIF-2895 - Extend product retriever with hook for product filters

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/relatedproducts/RelatedProductsRetriever.java
@@ -55,8 +55,17 @@ class RelatedProductsRetriever extends AbstractProductsRetriever {
 
     @Override
     protected String generateQuery(List<String> identifiers) {
-        ProductAttributeFilterInput filter = new ProductAttributeFilterInput().setSku(new FilterEqualTypeInput().setEq(identifiers.get(0)));
-        QueryQuery.ProductsArgumentsDefinition searchArgs = s -> s.filter(filter);
+        ProductAttributeFilterInput filter = new ProductAttributeFilterInput();
+        FilterEqualTypeInput skuFilter = new FilterEqualTypeInput().setEq(identifiers.get(0));
+        filter.setSku(skuFilter);
+
+        // Apply product attribute filter hook
+        if (this.productAttributeFilterHook != null) {
+            filter = this.productAttributeFilterHook.apply(filter);
+        }
+
+        ProductAttributeFilterInput finalFilter = filter;
+        QueryQuery.ProductsArgumentsDefinition searchArgs = s -> s.filter(finalFilter);
 
         ProductInterfaceQueryDefinition def;
         if (RelationType.UPSELL_PRODUCTS.equals(relationtype)) {

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductsRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductsRetriever.java
@@ -18,6 +18,7 @@ package com.adobe.cq.commerce.core.components.models.retriever;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -47,6 +48,11 @@ public abstract class AbstractProductsRetriever extends AbstractRetriever {
      * Lambda that extends the product variant query.
      */
     protected Consumer<SimpleProductQuery> variantQueryHook;
+
+    /**
+     * Lambda that allows to replace or extend the product attribute filters.
+     */
+    protected Function<ProductAttributeFilterInput, ProductAttributeFilterInput> productAttributeFilterHook;
 
     /**
      * List of product instances. Is only available after populate() was called.
@@ -124,15 +130,58 @@ public abstract class AbstractProductsRetriever extends AbstractRetriever {
     }
 
     /**
+     * Extends or replaces the product attribute filter with a custom instance defined by a lambda hook.
+     *
+     * Example 1 (Extend):
+     *
+     * <pre>
+     * {@code
+     * productsRetriever.extendProductFilterWith(f -> f
+     *     .setCustomFilter("my-attribute", new FilterEqualTypeInput()
+     *         .setEq("my-value")));
+     * }
+     * </pre>
+     *
+     * Example 2 (Replace):
+     *
+     * <pre>
+     * {@code
+     * productsRetriever.extendProductFilterWith(f -> new ProductAttributeFilterInput()
+     *     .setSku(new FilterEqualTypeInput()
+     *         .setEq("custom-sku"))
+     *     .setCustomFilter("my-attribute", new FilterEqualTypeInput()
+     *         .setEq("my-value")));
+     * }
+     * </pre>
+     *
+     * @param productAttributeFilterHook Lambda that extends or replaces the product attribute filter.
+     */
+    public void extendProductFilterWith(Function<ProductAttributeFilterInput, ProductAttributeFilterInput> productAttributeFilterHook) {
+        if (this.productAttributeFilterHook == null) {
+            this.productAttributeFilterHook = productAttributeFilterHook;
+        } else {
+            this.productAttributeFilterHook = this.productAttributeFilterHook.andThen(productAttributeFilterHook);
+        }
+    }
+
+    /**
      * Generate a complete product GraphQL query with a filter for the given product identifiers.
      *
      * @param identifiers product SKUs
      * @return GraphQL query as string
      */
     protected String generateQuery(List<String> identifiers) {
+        ProductAttributeFilterInput filter = new ProductAttributeFilterInput();
         FilterEqualTypeInput skuFilter = new FilterEqualTypeInput().setIn(identifiers);
-        ProductAttributeFilterInput filter = new ProductAttributeFilterInput().setSku(skuFilter);
-        QueryQuery.ProductsArgumentsDefinition searchArgs = s -> s.filter(filter);
+        filter.setSku(skuFilter);
+
+        // Apply product attribute filter hook
+        if (this.productAttributeFilterHook != null) {
+            filter = this.productAttributeFilterHook.apply(filter);
+        }
+
+        ProductAttributeFilterInput finalFilter = filter;
+        QueryQuery.ProductsArgumentsDefinition searchArgs = s -> s.filter(finalFilter);
 
         ProductsQueryDefinition queryArgs = q -> q.items(generateProductQuery());
         return Operations.query(query -> query

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("2.0.0")
+@Version("2.1.0")
 package com.adobe.cq.commerce.core.components.models.retriever;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractCategoryRetrieverTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractCategoryRetrieverTest.java
@@ -17,6 +17,7 @@ package com.adobe.cq.commerce.core.components.models.retriever;
 
 import java.util.Collections;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -24,8 +25,11 @@ import org.mockito.MockitoAnnotations;
 
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+import com.adobe.cq.commerce.magento.graphql.CategoryFilterInput;
 import com.adobe.cq.commerce.magento.graphql.CategoryInterface;
 import com.adobe.cq.commerce.magento.graphql.CategoryTreeQueryDefinition;
+import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
+import com.adobe.cq.commerce.magento.graphql.FilterMatchTypeInput;
 import com.adobe.cq.commerce.magento.graphql.Query;
 import com.adobe.cq.commerce.magento.graphql.gson.Error;
 
@@ -89,5 +93,22 @@ public class AbstractCategoryRetrieverTest {
         assertNull(category);
 
         verify(client, times(1)).execute(any());
+    }
+
+    @Test
+    public void testExtendFilterWithHook() {
+        subject.extendCategoryFilterWith(f -> f.setName(new FilterMatchTypeInput().setMatch("my-name")));
+
+        String query = subject.generateQuery("abc");
+        Assert.assertEquals("{categoryList(filters:{category_uid:{eq:\"abc\"},name:{match:\"my-name\"}}){uid}}", query);
+    }
+
+    @Test
+    public void testReplaceAndExtendFilterWithHook() {
+        subject.extendCategoryFilterWith(f -> new CategoryFilterInput().setUrlPath(new FilterEqualTypeInput().setEq("a/b/my-category")));
+        subject.extendCategoryFilterWith(f -> f.setName(new FilterMatchTypeInput().setMatch("my-name")));
+
+        String query = subject.generateQuery("abc");
+        Assert.assertEquals("{categoryList(filters:{name:{match:\"my-name\"},url_path:{eq:\"a/b/my-category\"}}){uid}}", query);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductRetrieverTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractProductRetrieverTest.java
@@ -17,6 +17,7 @@ package com.adobe.cq.commerce.core.components.models.retriever;
 
 import java.util.Collections;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -24,6 +25,9 @@ import org.mockito.MockitoAnnotations;
 
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
+import com.adobe.cq.commerce.magento.graphql.FilterMatchTypeInput;
+import com.adobe.cq.commerce.magento.graphql.ProductAttributeFilterInput;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
 import com.adobe.cq.commerce.magento.graphql.ProductInterfaceQueryDefinition;
 import com.adobe.cq.commerce.magento.graphql.Products;
@@ -93,5 +97,22 @@ public class AbstractProductRetrieverTest {
         assertNull(product);
 
         verify(client, times(1)).execute(any());
+    }
+
+    @Test
+    public void testExtendFilterWithHook() {
+        subject.extendProductFilterWith(f -> f.setName(new FilterMatchTypeInput().setMatch("my-name")));
+
+        String query = subject.generateQuery("abc");
+        Assert.assertEquals("{products(filter:{name:{match:\"my-name\"},sku:{eq:\"abc\"}}){items{__typename,sku}}}", query);
+    }
+
+    @Test
+    public void testReplaceAndExtendFilterWithHook() {
+        subject.extendProductFilterWith(f -> new ProductAttributeFilterInput().setUrlKey(new FilterEqualTypeInput().setEq("my-product")));
+        subject.extendProductFilterWith(f -> f.setName(new FilterMatchTypeInput().setMatch("my-name")));
+
+        String query = subject.generateQuery("abc");
+        Assert.assertEquals("{products(filter:{name:{match:\"my-name\"},url_key:{eq:\"my-product\"}}){items{__typename,sku}}}", query);
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,7 +108,7 @@
         <slf4j.version>1.7.6</slf4j.version>
         <jacoco.version>0.8.7</jacoco.version>
         <graphql.client.version>1.7.7</graphql.client.version>
-        <magento.graphql.version>11.0.1-magento244ee-SNAPSHOT</magento.graphql.version>
+        <magento.graphql.version>9.1.0-magento242ee-SNAPSHOT</magento.graphql.version>
 
         <core.wcm.components.version>2.18.6</core.wcm.components.version>
         <core.wcm.components.library.version>2.9.0</core.wcm.components.library.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,7 +108,7 @@
         <slf4j.version>1.7.6</slf4j.version>
         <jacoco.version>0.8.7</jacoco.version>
         <graphql.client.version>1.7.7</graphql.client.version>
-        <magento.graphql.version>9.0.0-magento242ee</magento.graphql.version>
+        <magento.graphql.version>11.0.1-magento244ee-SNAPSHOT</magento.graphql.version>
 
         <core.wcm.components.version>2.18.6</core.wcm.components.version>
         <core.wcm.components.library.version>2.9.0</core.wcm.components.library.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,7 +108,7 @@
         <slf4j.version>1.7.6</slf4j.version>
         <jacoco.version>0.8.7</jacoco.version>
         <graphql.client.version>1.7.7</graphql.client.version>
-        <magento.graphql.version>9.1.0-magento242ee-SNAPSHOT</magento.graphql.version>
+        <magento.graphql.version>9.1.0-magento242ee</magento.graphql.version>
 
         <core.wcm.components.version>2.18.6</core.wcm.components.version>
         <core.wcm.components.library.version>2.9.0</core.wcm.components.library.version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Added `extendCategoryFilterWith` and `extendProductFilterWith` to retrievers that support hooks to enable full replacement or extension of category and product query filters.
* Added unit tests.

Requires a release of https://github.com/adobe/commerce-cif-magento-graphql/pull/29 before it can be merged.

## Related Issue

See https://github.com/adobe/commerce-cif-magento-graphql/pull/27

## How Has This Been Tested?

* Unit tests + Venia example

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
