### PR TITLE
CIF-2865: Consistently add path to DataLayer event's eventInfo

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselBase.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcarousel/ProductCarouselBase.java
@@ -64,8 +64,7 @@ public class ProductCarouselBase extends DataLayerComponent {
         ValueMap properties = resource.getValueMap();
         ComponentsConfiguration configProperties = currentPage.adaptTo(Resource.class).adaptTo(ComponentsConfiguration.class);
         addToCartEnabled = properties.get(PN_ENABLE_ADD_TO_CART, currentStyle.get(PN_ENABLE_ADD_TO_CART, ENABLE_ADD_TO_CART_DEFAULT));
-        addToWishListEnabled = (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS,
-            ENABLE_ADD_TO_WISH_LIST_DEFAULT) : ENABLE_ADD_TO_WISH_LIST_DEFAULT);
+        addToWishListEnabled = (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS, Boolean.TRUE) : Boolean.TRUE);
         addToWishListEnabled = addToWishListEnabled && properties.get(PN_ENABLE_ADD_TO_WISH_LIST, currentStyle.get(
             PN_ENABLE_ADD_TO_WISH_LIST, ENABLE_ADD_TO_WISH_LIST_DEFAULT));
     }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcollection/ProductCollectionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcollection/ProductCollectionImpl.java
@@ -113,8 +113,7 @@ public class ProductCollectionImpl extends DataLayerComponent implements Product
 
         addToCartEnabled = currentStyle.get(PN_ENABLE_ADD_TO_CART, ENABLE_ADD_TO_CART_DEFAULT);
 
-        addToWishListEnabled = (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS,
-            ENABLE_ADD_TO_WISH_LIST_DEFAULT) : ENABLE_ADD_TO_WISH_LIST_DEFAULT);
+        addToWishListEnabled = (configProperties != null ? configProperties.get(PN_CONFIG_ENABLE_WISH_LISTS, Boolean.TRUE) : Boolean.TRUE);
         addToWishListEnabled = addToWishListEnabled && currentStyle.get(PN_ENABLE_ADD_TO_WISH_LIST, ENABLE_ADD_TO_WISH_LIST_DEFAULT);
     }
 

--- a/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/internal/models/v1/productrecommendations/ProductRecommendationsImpl.java
+++ b/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/internal/models/v1/productrecommendations/ProductRecommendationsImpl.java
@@ -29,6 +29,8 @@ import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.extensions.recommendations.internal.models.v1.common.PriceRangeImpl;
 import com.adobe.cq.commerce.extensions.recommendations.models.common.PriceRange;
 import com.adobe.cq.commerce.extensions.recommendations.models.productrecommendations.ProductRecommendations;
+import com.adobe.cq.wcm.core.components.models.Component;
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
 
@@ -63,6 +65,28 @@ public class ProductRecommendationsImpl implements ProductRecommendations {
     @Self
     @Via("resource")
     private ValueMap props;
+    @Self
+    private Component component;
+
+    @Override
+    public String getId() {
+        return component.getId();
+    }
+
+    @Override
+    public ComponentData getData() {
+        return component.getData();
+    }
+
+    @Override
+    public String getAppliedCssClasses() {
+        return component.getAppliedCssClasses();
+    }
+
+    @Override
+    public String getExportedType() {
+        return component.getExportedType();
+    }
 
     private String getStringListProperty(String propertyName) {
         Object property = props.get(propertyName);

--- a/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/models/productrecommendations/ProductRecommendations.java
+++ b/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/models/productrecommendations/ProductRecommendations.java
@@ -18,13 +18,14 @@ package com.adobe.cq.commerce.extensions.recommendations.models.productrecommend
 import org.osgi.annotation.versioning.ConsumerType;
 
 import com.adobe.cq.commerce.extensions.recommendations.models.common.PriceRange;
+import com.adobe.cq.wcm.core.components.models.Component;
 
 /**
  * Sling model for a product recommendation component
  * The model holds all the configured options
  */
 @ConsumerType
-public interface ProductRecommendations {
+public interface ProductRecommendations extends Component {
 
     boolean getPreconfigured();
 

--- a/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/models/productrecommendations/package-info.java
+++ b/extensions/product-recs/bundle/src/main/java/com/adobe/cq/commerce/extensions/recommendations/models/productrecommendations/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("2.5.0")
+@Version("2.6.0")
 package com.adobe.cq.commerce.extensions.recommendations.models.productrecommendations;
 
 import org.osgi.annotation.versioning.Version;

--- a/extensions/product-recs/content/src/main/content/jcr_root/apps/core/cif/extensions/product-recs/components/productrecommendations/v1/productrecommendations/productrecommendations.html
+++ b/extensions/product-recs/content/src/main/content/jcr_root/apps/core/cif/extensions/product-recs/components/productrecommendations/v1/productrecommendations/productrecommendations.html
@@ -17,6 +17,8 @@
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"/>
 <div
         data-is-product-recs
+        data-cmp-is="productrecommendations"
+        data-cmp-data-layer="${recommendations.data.json}"
         data-title="${recommendations.title}"
         data-preconfigured="${recommendations.preconfigured}"
         data-recommendation-type="${recommendations.recommendationType}"

--- a/extensions/product-recs/react-components/src/components/ProductRecsGallery/ProductCard.js
+++ b/extensions/product-recs/react-components/src/components/ProductRecsGallery/ProductCard.js
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { useIntl } from 'react-intl';
@@ -25,6 +25,8 @@ const ProductCard = props => {
     const { showAddToWishList } = props;
     const mse = useStorefrontEvents();
     const intl = useIntl();
+    const addToCartRef = useRef();
+    const addToWishlistRef = useRef();
 
     const {
         unit: { unitId },
@@ -36,9 +38,10 @@ const ProductCard = props => {
         const { unitId } = unit;
 
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+            bubbles: true,
             detail: [{ sku, quantity: 1, virtual: type === 'virtual' }]
         });
-        document.dispatchEvent(customEvent);
+        addToCartRef.current.dispatchEvent(customEvent);
 
         mse && mse.publish.recsItemAddToCartClick(unitId, productId);
     };
@@ -47,9 +50,10 @@ const ProductCard = props => {
         const { sku } = product;
 
         const customEvent = new CustomEvent('aem.cif.add-to-wishlist', {
+            bubbles: true,
             detail: [{ sku, quantity: 1 }]
         });
-        document.dispatchEvent(customEvent);
+        addToWishlistRef.current.dispatchEvent(customEvent);
     };
 
     const openDetails = (unit, product) => {
@@ -109,14 +113,14 @@ const ProductCard = props => {
                             openDetails(props.unit, props.product);
                         }
                     }}>
-                    <span className={classes.addToCart}>
+                    <span className={classes.addToCart} ref={addToCartRef}>
                         {intl.formatMessage({ id: 'productrecs:add-to-cart', defaultMessage: 'Add to Cart' })}
                     </span>
                 </Trigger>
             }
             {showAddToWishList && (
                 <Trigger className={classes.buttonMargin} action={() => addToWishlist(props.product)}>
-                    <span className={classes.addToWishlist}>
+                    <span className={classes.addToWishlist} ref={addToWishlistRef}>
                         {intl.formatMessage({ id: 'productrecs:add-to-wishlist', defaultMessage: 'Add to Wish List' })}
                     </span>
                 </Trigger>

--- a/extensions/product-recs/react-components/src/components/ProductRecsGallery/ProductRecsGallery.js
+++ b/extensions/product-recs/react-components/src/components/ProductRecsGallery/ProductRecsGallery.js
@@ -51,11 +51,19 @@ const ProductRecsGallery = props => {
     }
 
     if (units && units.length > 0 && units[0].products.length > 0) {
+        let parentId;
         const unit = units[0];
 
         const isVisible = () => {
             mse && mse.publish.recsUnitView(unit.unitId);
         };
+
+        if (hostElement) {
+            const dataLayerStr = hostElement.dataset?.cmpDataLayer;
+            const dataLayer = dataLayerStr ? JSON.parse(dataLayerStr) : {};
+            const dataLayerKeys = Object.keys(dataLayer);
+            parentId = dataLayerKeys.length > 0 ? dataLayerKeys[0] : undefined;
+        }
 
         content = (
             <>
@@ -63,6 +71,7 @@ const ProductRecsGallery = props => {
                 <div className={classes.container} ref={e => observeElement(e, isVisible)}>
                     {unit.products.map(product => (
                         <ProductCard
+                            parentId={parentId}
                             unit={unit}
                             product={product}
                             key={product.sku}

--- a/react-components/package.json
+++ b/react-components/package.json
@@ -19,6 +19,7 @@
     "webpack:dev": "npm run i18n:extract-compile && webpack --mode=development",
     "webpack:prod": "npm run i18n:extract-compile && webpack --mode=production && node css-template.js",
     "test": "npm run i18n:extract-compile && npm run lint && npm run prettier:check && jest --coverage",
+    "jest": "jest --coverage",
     "ci": "npm run i18n:extract-compile && npm run lint && npm run prettier:check && jest --ci --runInBand --coverage",
     "test:watch": "npm run i18n:extract-compile && npm run lint && jest --watch",
     "prettier:check": "prettier --check '{src,test}/**/*.{js,css}' --config ./.prettierrc",

--- a/react-components/src/components/BundleProductOptions/__test__/bundleProductOptions.test.js
+++ b/react-components/src/components/BundleProductOptions/__test__/bundleProductOptions.test.js
@@ -87,9 +87,10 @@ describe('BundleProductOptions', () => {
             });
         });
 
-        const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent').mockImplementation(event => {
+        const eventHandler = jest.fn().mockImplementation(event => {
             return event.detail;
         });
+        document.addEventListener('aem.cif.add-to-cart', eventHandler);
 
         const bundleProductOptionsContainer = document.createElement('div');
         bundleProductOptionsContainer.dataset.sku = 'VA24';
@@ -115,10 +116,10 @@ describe('BundleProductOptions', () => {
         fireEvent.click(getByRole('button', { name: 'Add to Cart' }));
 
         // Add to cart should be called just once since the second click was on a disabled button
-        await wait(() => expect(dispatchEventSpy).toHaveBeenCalledTimes(1));
+        await wait(() => expect(eventHandler).toHaveBeenCalledTimes(1));
 
         // The mock dispatchEvent function returns the CustomEvent detail
-        expect(dispatchEventSpy).toHaveReturnedWith([
+        expect(eventHandler).toHaveReturnedWith([
             {
                 bundle: true,
                 options: [
@@ -140,8 +141,6 @@ describe('BundleProductOptions', () => {
                 virtual: false
             }
         ]);
-
-        dispatchEventSpy.mockClear();
     });
 
     it('renders add to wish list button', async () => {
@@ -160,9 +159,10 @@ describe('BundleProductOptions', () => {
         bundleProductOptionsContainer.dataset.showAddToWishList = '';
         bundleProductOptionsContainer.id = 'bundle-product-options';
 
-        const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent').mockImplementation(event => {
+        const eventHandler = jest.fn().mockImplementation(event => {
             return event.detail;
         });
+        document.addEventListener('aem.cif.add-to-wishlist', eventHandler);
 
         const { asFragment, container, getByRole } = render(<BundleProductOptions />, {
             config: config,
@@ -178,10 +178,10 @@ describe('BundleProductOptions', () => {
 
         fireEvent.click(getByRole('button', { name: 'Add to Wish List' }));
 
-        await wait(() => expect(dispatchEventSpy).toHaveBeenCalledTimes(1));
+        await wait(() => expect(eventHandler).toHaveBeenCalledTimes(1));
 
         // The mock dispatchEvent function returns the CustomEvent detail
-        expect(dispatchEventSpy).toHaveReturnedWith([
+        expect(eventHandler).toHaveReturnedWith([
             {
                 quantity: 1,
                 selected_options: [
@@ -194,7 +194,5 @@ describe('BundleProductOptions', () => {
                 sku: 'VA24'
             }
         ]);
-
-        dispatchEventSpy.mockClear();
     });
 });

--- a/react-components/src/components/BundleProductOptions/bundleProductOptions.js
+++ b/react-components/src/components/BundleProductOptions/bundleProductOptions.js
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useConfigContext } from '../../context/ConfigContext';
@@ -34,12 +34,17 @@ const BundleProductOptions = props => {
     const {
         mountingPoints: { bundleProductOptionsContainer }
     } = useConfigContext();
-    const productId = document.querySelector('[data-cmp-is=product]')?.id;
+    const productComponentEl = document.querySelector('[data-cmp-is=product]');
+    const bundleProductOptionsContainerEl = document.querySelector(bundleProductOptionsContainer);
+    const productId = productComponentEl?.id;
     const [bundleState, setBundleState] = useState(null);
     const intl = useIntl();
+    const addToCartRef = useRef();
+    const addToWishlistRef = useRef();
+
     let { sku, showAddToWishList, showQuantity, useUid, autoLoadOptions } = {
         ...props,
-        ...(document.querySelector(bundleProductOptionsContainer)?.dataset || {})
+        ...(bundleProductOptionsContainerEl?.dataset || {})
     };
 
     // show-add-to-wish-list is set without a value to the dom,
@@ -189,9 +194,11 @@ const BundleProductOptions = props => {
             selected_options
         };
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+            bubbles: true,
             detail: [productData]
         });
-        document.dispatchEvent(customEvent);
+
+        addToCartRef.current.dispatchEvent(customEvent);
     };
 
     const addToWishlist = () => {
@@ -209,9 +216,10 @@ const BundleProductOptions = props => {
         };
 
         const customEvent = new CustomEvent('aem.cif.add-to-wishlist', {
+            bubbles: true,
             detail: [productData]
         });
-        document.dispatchEvent(customEvent);
+        addToWishlistRef.current.dispatchEvent(customEvent);
     };
 
     const getTotalPrice = () => {
@@ -330,7 +338,8 @@ const BundleProductOptions = props => {
                         className="button__root_highPriority button__root clickable__root button__filled"
                         type="button"
                         disabled={!canAddToCart()}
-                        onClick={addToCart}>
+                        onClick={addToCart}
+                        ref={addToCartRef}>
                         <span className="button__content">
                             <span>{intl.formatMessage({ id: 'product:add-item', defaultMessage: 'Add to Cart' })}</span>
                         </span>
@@ -339,7 +348,8 @@ const BundleProductOptions = props => {
                         <button
                             className="button__root_normalPriority button__root clickable__root"
                             type="button"
-                            onClick={addToWishlist}>
+                            onClick={addToWishlist}
+                            ref={addToWishlistRef}>
                             <span className="button__content">
                                 <span>
                                     {intl.formatMessage({

--- a/react-components/src/components/GiftCardOptions/__test__/giftCardOptions.test.js
+++ b/react-components/src/components/GiftCardOptions/__test__/giftCardOptions.test.js
@@ -30,12 +30,14 @@ const config = {
 };
 
 describe('GiftCardProductOptions', () => {
-    const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent').mockImplementation(event => {
+    const eventHandler = jest.fn().mockImplementation(event => {
         return event.detail;
     });
+    document.addEventListener('aem.cif.add-to-cart', eventHandler);
+    document.addEventListener('aem.cif.add-to-wishlist', eventHandler);
 
     afterEach(() => {
-        dispatchEventSpy.mockClear();
+        eventHandler.mockClear();
     });
 
     it('renders the component with no sku', () => {
@@ -89,7 +91,7 @@ describe('GiftCardProductOptions', () => {
 
         // Click add to cart which should be disabled
         fireEvent.click(getByRole('button', { name: 'Add to Cart' }));
-        expect(dispatchEventSpy).toHaveBeenCalledTimes(0);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
 
         // Add the required inputs
         fireEvent.change(getByLabelText(/amount/i), {
@@ -103,10 +105,10 @@ describe('GiftCardProductOptions', () => {
         fireEvent.click(getByRole('button', { name: 'Add to Cart' }));
 
         // Add to cart should be called just once since the first click was on a disabled button
-        await wait(() => expect(dispatchEventSpy).toHaveBeenCalledTimes(1));
+        await wait(() => expect(eventHandler).toHaveBeenCalledTimes(1));
 
         // The mock dispatchEvent function returns the CustomEvent detail
-        expect(dispatchEventSpy).toHaveReturnedWith([
+        expect(eventHandler).toHaveReturnedWith([
             {
                 sku: 'gift-card',
                 parentSku: 'gift-card',
@@ -157,9 +159,9 @@ describe('GiftCardProductOptions', () => {
         fireEvent.click(getByRole('button', { name: 'Add to Wish List' }));
 
         // Add to cart should be called just once since the first click was on a disabled button
-        await wait(() => expect(dispatchEventSpy).toHaveBeenCalledTimes(1));
+        await wait(() => expect(eventHandler).toHaveBeenCalledTimes(1));
 
-        expect(dispatchEventSpy).toHaveReturnedWith([
+        expect(eventHandler).toHaveReturnedWith([
             {
                 sku: 'gift-card',
                 quantity: 1

--- a/react-components/src/components/GiftCardOptions/giftCardOptions.js
+++ b/react-components/src/components/GiftCardOptions/giftCardOptions.js
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
 import LoadingIndicator from '../LoadingIndicator';
@@ -64,6 +64,8 @@ const GiftCardOptions = props => {
     ] = useGiftCardOptions({ sku, useUid });
 
     const intl = useIntl();
+    const addToCartRef = useRef();
+    const addToWishListRef = useRef();
 
     if (giftCardState === null) {
         return <LoadingIndicator />;
@@ -242,7 +244,8 @@ const GiftCardOptions = props => {
                     className="button__root_highPriority button__root clickable__root button__filled"
                     type="button"
                     disabled={!canAddToCart()}
-                    onClick={addToCart}>
+                    onClick={() => addToCart(addToCartRef.current)}
+                    ref={addToCartRef}>
                     <span className="button__content">
                         <span>{intl.formatMessage({ id: 'product:add-item', defaultMessage: 'Add to Cart' })}</span>
                     </span>
@@ -251,7 +254,8 @@ const GiftCardOptions = props => {
                     <button
                         className="button__root_normalPriority button__root clickable__root"
                         type="button"
-                        onClick={addToWishlist}>
+                        onClick={() => addToWishlist(addToWishListRef.current)}
+                        ref={addToWishListRef}>
                         <span className="button__content">
                             <span>
                                 {intl.formatMessage({

--- a/react-components/src/components/GiftCardOptions/useGiftCardOptions.js
+++ b/react-components/src/components/GiftCardOptions/useGiftCardOptions.js
@@ -140,7 +140,7 @@ const useGiftCardOptions = props => {
         return true;
     };
 
-    const addToCart = () => {
+    const addToCart = (eventTarget = document) => {
         if (canAddToCart()) {
             const {
                 giftCardValues: {
@@ -170,21 +170,23 @@ const useGiftCardOptions = props => {
             }
 
             const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+                bubbles: true,
                 detail: [productData]
             });
-            document.dispatchEvent(customEvent);
+            eventTarget.dispatchEvent(customEvent);
         }
     };
 
-    const addToWishlist = () => {
+    const addToWishlist = (eventTarget = document) => {
         const {
             giftCardValues: { quantity }
         } = giftCardState;
         const productData = { sku, quantity };
         const customEvent = new CustomEvent('aem.cif.add-to-wishlist', {
+            bubbles: true,
             detail: [productData]
         });
-        document.dispatchEvent(customEvent);
+        eventTarget.dispatchEvent(customEvent);
     };
 
     return [

--- a/react-components/src/index.js
+++ b/react-components/src/index.js
@@ -50,3 +50,6 @@ export { useAddToCart, useAddToCartEvent } from './talons/Cart';
 
 // new since CIF-2539
 export { useAddToWishlistEvent } from './talons/Wishlist';
+
+// new since CIF-2865
+export { default as dataLayerUtils } from './utils/dataLayerUtils';

--- a/react-components/src/utils/__test__/useDataLayerEvents.test.js
+++ b/react-components/src/utils/__test__/useDataLayerEvents.test.js
@@ -29,6 +29,7 @@ describe('useDataLayerEvents', () => {
         renderHook(() => useDataLayerEvents());
         act(() => {
             const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+                bubbles: true,
                 detail: [{ productId: 'test-id', sku: 'test-sku', quantity: 1 }]
             });
             document.dispatchEvent(customEvent);
@@ -46,6 +47,7 @@ describe('useDataLayerEvents', () => {
         renderHook(() => useDataLayerEvents());
         act(() => {
             const customEvent = new CustomEvent('aem.cif.add-to-wishlist', {
+                bubbles: true,
                 detail: [{ productId: 'test-id', sku: 'test-sku', quantity: 1 }]
             });
             document.dispatchEvent(customEvent);
@@ -56,6 +58,68 @@ describe('useDataLayerEvents', () => {
             '@id': 'test-id',
             'xdm:SKU': 'test-sku',
             'xdm:quantity': 1
+        });
+    });
+
+    it('includes the event targets component id as path', () => {
+        const button = document.createElement('button');
+        button.dataset.cmpDataLayer = JSON.stringify({ 'component-id-1234': {} });
+        document.body.appendChild(button);
+
+        renderHook(() => useDataLayerEvents());
+        act(() => {
+            const bubbles = true;
+            const detail = [{ productId: 'test-id', sku: 'test-sku', quantity: 1 }];
+            let customEvent = new CustomEvent('aem.cif.add-to-cart', { bubbles, detail });
+            button.dispatchEvent(customEvent);
+
+            customEvent = new CustomEvent('aem.cif.add-to-wishlist', { bubbles, detail });
+            button.dispatchEvent(customEvent);
+        });
+
+        expect(pushEvent).toHaveBeenCalledWith('cif:addToCart', {
+            '@id': 'test-id',
+            'xdm:SKU': 'test-sku',
+            'xdm:quantity': 1,
+            path: 'component.component-id-1234'
+        });
+        expect(pushEvent).toHaveBeenCalledWith('cif:addToWishList', {
+            '@id': 'test-id',
+            'xdm:SKU': 'test-sku',
+            'xdm:quantity': 1,
+            path: 'component.component-id-1234'
+        });
+    });
+
+    it('includes the event targets ancestors component id as path', () => {
+        const component = document.createElement('div');
+        const button = document.createElement('button');
+        component.dataset.cmpDataLayer = JSON.stringify({ 'parent-component-id-1234': {} });
+        component.appendChild(button);
+        document.body.appendChild(component);
+
+        renderHook(() => useDataLayerEvents());
+        act(() => {
+            const bubbles = true;
+            const detail = [{ productId: 'test-id', sku: 'test-sku', quantity: 1 }];
+            let customEvent = new CustomEvent('aem.cif.add-to-cart', { bubbles, detail });
+            button.dispatchEvent(customEvent);
+
+            customEvent = new CustomEvent('aem.cif.add-to-wishlist', { bubbles, detail });
+            button.dispatchEvent(customEvent);
+        });
+
+        expect(pushEvent).toHaveBeenCalledWith('cif:addToCart', {
+            '@id': 'test-id',
+            'xdm:SKU': 'test-sku',
+            'xdm:quantity': 1,
+            path: 'component.parent-component-id-1234'
+        });
+        expect(pushEvent).toHaveBeenCalledWith('cif:addToWishList', {
+            '@id': 'test-id',
+            'xdm:SKU': 'test-sku',
+            'xdm:quantity': 1,
+            path: 'component.parent-component-id-1234'
         });
     });
 });

--- a/react-components/src/utils/dataLayerUtils.js
+++ b/react-components/src/utils/dataLayerUtils.js
@@ -154,3 +154,11 @@ export const transformCart = cart => {
 };
 
 export { transformGraphqlResponse };
+
+export default {
+    isEnabled: isDataLayerEnabled,
+    getState,
+    pushEvent,
+    pushData,
+    generateId: generateDataLayerId
+}

--- a/react-components/src/utils/useDataLayerEvents.js
+++ b/react-components/src/utils/useDataLayerEvents.js
@@ -17,8 +17,29 @@ import { useEventListener } from './hooks';
 import * as dataLayerUtils from './dataLayerUtils';
 
 const useDataLayerEvents = () => {
+    const getClickId = element => {
+        if (element === document) {
+            return undefined;
+        }
+
+        if (element.dataset?.cmpDataLayer) {
+            return Object.keys(JSON.parse(element.dataset.cmpDataLayer))[0];
+        }
+
+        // if the target itself does not have a component data layer data
+        // find the closes parent
+        const componentElement = element.closest('[data-cmp-data-layer]');
+        if (componentElement) {
+            return getClickId(componentElement);
+        }
+
+        return undefined;
+    };
+
     useEventListener(document, 'aem.cif.add-to-cart', async event => {
         const items = typeof event.detail === 'string' ? JSON.parse(event.detail) : event.detail;
+        const componentId = getClickId(event.target);
+
         items.forEach(item => {
             let eventInfo = {
                 '@id': item.productId,
@@ -27,7 +48,11 @@ const useDataLayerEvents = () => {
             };
 
             if (item.bundle) {
-                eventInfo['bundle'] = true;
+                eventInfo.bundle = true;
+            }
+
+            if (componentId) {
+                eventInfo.path = 'component.' + componentId;
             }
 
             dataLayerUtils.pushEvent('cif:addToCart', eventInfo);
@@ -36,12 +61,22 @@ const useDataLayerEvents = () => {
 
     useEventListener(document, 'aem.cif.add-to-wishlist', async event => {
         const items = typeof event.detail === 'string' ? JSON.parse(event.detail) : event.detail;
+        const componentId = getClickId(event.target);
+
         items.forEach(item => {
             let eventInfo = {
                 '@id': item.productId,
                 'xdm:SKU': item.sku,
                 'xdm:quantity': item.quantity
             };
+
+            if (item.bundle) {
+                eventInfo.bundle = true;
+            }
+
+            if (componentId) {
+                eventInfo.path = 'component.' + componentId;
+            }
 
             dataLayerUtils.pushEvent('cif:addToWishList', eventInfo);
         });

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToCart.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToCart.js
@@ -93,13 +93,15 @@ class AddToCart {
     /**
      * Click event handler for add to cart button.
      */
-    _onAddToCart() {
+    _onAddToCart(event) {
+        const target = event.currentTarget;
         const items = this._getEventDetail();
         if (items.length > 0 && window.CIF) {
             const customEvent = new CustomEvent(AddToCart.events.addToCart, {
+                bubbles: true,
                 detail: items
             });
-            document.dispatchEvent(customEvent);
+            target.dispatchEvent(customEvent);
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToCart.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToCart.js
@@ -102,6 +102,8 @@ class AddToCart {
                 detail: items
             });
             target.dispatchEvent(customEvent);
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToWishlist.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v1/product/clientlib/js/addToWishlist.js
@@ -39,13 +39,17 @@ class AddToWishlist {
     /**
      * Click event handler for add to whislist button.
      */
-    _onAddToWishlist() {
+    _onAddToWishlist(event) {
+        const target = event.currentTarget;
         const items = this._getEventDetail();
         if (items.length > 0 && window.CIF) {
             const customEvent = new CustomEvent(AddToWishlist.events.addToWishlist, {
+                bubbles: true,
                 detail: items
             });
-            document.dispatchEvent(customEvent);
+            target.dispatchEvent(customEvent);
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v3/product/clientlib/js/addToCart.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v3/product/clientlib/js/addToCart.js
@@ -100,6 +100,8 @@ class AddToCart {
                 detail: items
             });
             target.dispatchEvent(customEvent);
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v3/product/clientlib/js/addToCart.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v3/product/clientlib/js/addToCart.js
@@ -91,13 +91,15 @@ class AddToCart {
     /**
      * Click event handler for add to cart button.
      */
-    _onAddToCart() {
+    _onAddToCart(event) {
+        const target = event.currentTarget;
         const items = this._getEventDetail();
         if (items.length > 0 && window.CIF) {
             const customEvent = new CustomEvent(AddToCart.events.addToCart, {
+                bubbles: true,
                 detail: items
             });
-            document.dispatchEvent(customEvent);
+            target.dispatchEvent(customEvent);
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v3/product/clientlib/js/addToWishlist.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/product/v3/product/clientlib/js/addToWishlist.js
@@ -39,13 +39,17 @@ class AddToWishlist {
     /**
      * Click event handler for add to whislist button.
      */
-    _onAddToWishlist() {
+    _onAddToWishlist(event) {
+        const target = event.currentTarget;
         const items = this._getEventDetail();
         if (items.length > 0 && window.CIF) {
             const customEvent = new CustomEvent(AddToWishlist.events.addToWishlist, {
+                bubbles: true,
                 detail: items
             });
-            document.dispatchEvent(customEvent);
+            target.dispatchEvent(customEvent);
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/clientlibs/js/actions.js
@@ -22,41 +22,41 @@ class ProductCarouselActions {
 
         element.querySelectorAll('.product__card-button--add-to-cart').forEach(actionButton => {
             let actionHandler = this._addToCartHandler.bind(this);
-            actionButton.addEventListener('click', ev => {
-                actionHandler(ev);
-            });
+            actionButton.addEventListener('click', ev => actionHandler(ev));
         });
 
         element.querySelectorAll('.product__card-button--add-to-wish-list').forEach(actionButton => {
             let actionHandler = this._addToWishlistHandler.bind(this);
-            actionButton.addEventListener('click', ev => {
-                ev.preventDefault();
-                const element = ev.currentTarget;
-                actionHandler(element.dataset);
-            });
+            actionButton.addEventListener('click', ev => actionHandler(ev));
         });
     }
 
-    _addToCartHandler(ev) {
-        const dataset = ev.currentTarget.dataset;
-        const sku = dataset['itemSku'];
-        const action = dataset['action'];
+    _addToCartHandler(event) {
+        const target = event.currentTarget;
+        const dataset = target.dataset;
+        const sku = dataset.itemSku;
+        const action = dataset.action;
         if (action === 'add-to-cart') {
             const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+                bubbles: true,
                 detail: [{ sku, quantity: 1, virtual: this.virtual }]
             });
-            document.dispatchEvent(customEvent);
-            ev.preventDefault();
+            target.dispatchEvent(customEvent);
+            event.preventDefault();
         }
         // else click hits parent link
     }
 
-    _addToWishlistHandler(dataset) {
-        const sku = dataset['itemSku'];
+    _addToWishlistHandler(event) {
+        const target = event.currentTarget;
+        const dataset = target.dataset;
+        const sku = dataset.itemSku;
         const customEvent = new CustomEvent('aem.cif.add-to-wishlist', {
+            bubbles: true,
             detail: [{ sku, quantity: 1 }]
         });
-        document.dispatchEvent(customEvent);
+        target.dispatchEvent(customEvent);
+        event.preventDefault();
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcarousel/v1/productcarousel/clientlibs/js/actions.js
@@ -43,6 +43,7 @@ class ProductCarouselActions {
             });
             target.dispatchEvent(customEvent);
             event.preventDefault();
+            event.stopPropagation();
         }
         // else click hits parent link
     }
@@ -57,6 +58,7 @@ class ProductCarouselActions {
         });
         target.dispatchEvent(customEvent);
         event.preventDefault();
+        event.stopPropagation();
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/actions.js
@@ -32,7 +32,6 @@ class ProductCollectionActions {
     }
 
     _addToCartHandler(event) {
-        event.stopPropagation();
         const target = event.currentTarget;
         const dataset = target.dataset;
         const sku = dataset.itemSku;
@@ -44,12 +43,12 @@ class ProductCollectionActions {
             });
             target.dispatchEvent(customEvent);
             event.preventDefault();
+            event.stopPropagation();
         }
         // else click hits parent link
     }
 
     _addToWishlistHandler(event) {
-        event.stopPropagation();
         const target = event.currentTarget;
         const dataset = target.dataset;
         const sku = dataset.itemSku;
@@ -59,6 +58,7 @@ class ProductCollectionActions {
         });
         target.dispatchEvent(customEvent);
         event.preventDefault();
+        event.stopPropagation();
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/actions.js
@@ -22,41 +22,43 @@ class ProductCollectionActions {
 
         element.querySelectorAll('.productcollection__item-button--add-to-cart').forEach(actionButton => {
             let actionHandler = this._addToCartHandler.bind(this);
-            actionButton.addEventListener('click', ev => {
-                actionHandler(ev);
-            });
+            actionButton.addEventListener('click', ev => actionHandler(ev));
         });
 
         element.querySelectorAll('.productcollection__item-button--add-to-wish-list').forEach(actionButton => {
             let actionHandler = this._addToWishlistHandler.bind(this);
-            actionButton.addEventListener('click', ev => {
-                ev.preventDefault();
-                const element = ev.currentTarget;
-                actionHandler(element.dataset);
-            });
+            actionButton.addEventListener('click', ev => actionHandler(ev));
         });
     }
 
-    _addToCartHandler(ev) {
-        const dataset = ev.currentTarget.dataset;
-        const sku = dataset['itemSku'];
-        const action = dataset['action'];
+    _addToCartHandler(event) {
+        event.stopPropagation();
+        const target = event.currentTarget;
+        const dataset = target.dataset;
+        const sku = dataset.itemSku;
+        const action = dataset.action;
         if (action === 'add-to-cart') {
             const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+                bubbles: true,
                 detail: [{ sku, quantity: 1, virtual: this.virtual }]
             });
-            document.dispatchEvent(customEvent);
-            ev.preventDefault();
+            target.dispatchEvent(customEvent);
+            event.preventDefault();
         }
         // else click hits parent link
     }
 
-    _addToWishlistHandler(dataset) {
-        const sku = dataset['itemSku'];
+    _addToWishlistHandler(event) {
+        event.stopPropagation();
+        const target = event.currentTarget;
+        const dataset = target.dataset;
+        const sku = dataset.itemSku;
         const customEvent = new CustomEvent('aem.cif.add-to-wishlist', {
+            bubbles: true,
             detail: [{ sku, quantity: 1 }]
         });
-        document.dispatchEvent(customEvent);
+        target.dispatchEvent(customEvent);
+        event.preventDefault();
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/productcollection.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/productcollection.js
@@ -15,6 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 'use strict';
 
+const awaitCommonClientLib = async () =>
+    new Promise(r => document.addEventListener('aem.cif.clientlib-initialized', r));
+
 class ProductCollection {
     constructor(config) {
         this._element = config.element;
@@ -56,10 +59,6 @@ class ProductCollection {
             loadPrices: this._element.dataset.loadClientPrice !== undefined
         };
 
-        // Intl.NumberFormat instance for formatting prices
-        this._formatter =
-            window.CIF && window.CIF.PriceFormatter && new window.CIF.PriceFormatter(this._element.dataset.locale);
-
         this._element.querySelectorAll(ProductCollection.selectors.item).forEach(item => {
             this._state.skus.push(item.dataset.sku);
         });
@@ -97,72 +96,85 @@ class ProductCollection {
         return price;
     }
 
-    _fetchPrices() {
+    async _fetchPrices() {
         // Retrieve current prices
-        if (!window.CIF || !window.CIF.CommerceGraphqlApi) return;
-        return window.CIF.CommerceGraphqlApi.getProductPrices(this._state.skus, false)
-            .then(prices => {
-                let convertedPrices = {};
-                for (let key in prices) {
-                    convertedPrices[key] = this._convertPriceToRange(prices[key]);
-                }
-                this._state.prices = convertedPrices;
+        if (!window.CIF || !window.CIF.CommerceGraphqlApi) {
+            await awaitCommonClientLib();
+        }
 
-                // Update prices
-                this._updatePrices();
-            })
-            .catch(err => {
-                console.error('Could not fetch prices', err);
-            });
+        try {
+            const prices = await window.CIF.CommerceGraphqlApi.getProductPrices(this._state.skus, false);
+
+            let convertedPrices = {};
+            for (let key in prices) {
+                convertedPrices[key] = this._convertPriceToRange(prices[key]);
+            }
+            this._state.prices = convertedPrices;
+
+            // Update prices
+            await this._updatePrices();
+        } catch (err) {
+            console.error('Could not fetch prices', err);
+        }
     }
 
-    _updatePrices() {
-        this._element.querySelectorAll(ProductCollection.selectors.item).forEach(item => {
-            if (!(item.dataset.sku in this._state.prices)) return;
+    async _updatePrices() {
+        if (!this._formatter) {
+            if (!window.CIF || !window.CIF.PriceFormatter) {
+                await awaitCommonClientLib();
+            }
+
+            this._formatter = new window.CIF.PriceFormatter(this._element.dataset.locale);
+        }
+
+        let _formatter = this._formatter;
+
+        for (let item of this._element.querySelectorAll(ProductCollection.selectors.item)) {
+            if (!(item.dataset.sku in this._state.prices)) continue;
 
             const price = this._state.prices[item.dataset.sku];
 
             let innerHTML = '';
             if (!price.range) {
                 if (price.discounted) {
-                    innerHTML += `<span class="regularPrice">${this._formatter.formatPrice({
+                    innerHTML += `<span class="regularPrice">${_formatter.formatPrice({
                         value: price.regularPrice,
                         currency: price.currency
                     })}</span>
-                        <span class="discountedPrice">${this._formatter.formatPrice({
+                        <span class="discountedPrice">${_formatter.formatPrice({
                             value: price.finalPrice,
                             currency: price.currency
                         })}</span>`;
                 } else {
-                    let prefix = price.isStartPrice ? this._formatter.get('Starting at') + ' ' : '';
-                    innerHTML += `<span>${prefix}${this._formatter.formatPrice({
+                    let prefix = price.isStartPrice ? _formatter.get('Starting at') + ' ' : '';
+                    innerHTML += `<span>${prefix}${_formatter.formatPrice({
                         value: price.regularPrice,
                         currency: price.currency
                     })}</span>`;
                 }
             } else {
-                let from = this._formatter.get('From');
-                let to = this._formatter.get('To');
+                let from = _formatter.get('From');
+                let to = _formatter.get('To');
                 if (price.discounted) {
-                    innerHTML += `<span class="regularPrice">${from} ${this._formatter.formatPrice({
+                    innerHTML += `<span class="regularPrice">${from} ${_formatter.formatPrice({
                         value: price.regularPrice,
                         currency: price.currency
-                    })} ${to} ${this._formatter.formatPrice({
+                    })} ${to} ${_formatter.formatPrice({
                         value: price.regularPriceMax,
                         currency: price.currency
                     })}</span>
-                        <span class="discountedPrice">${from} ${this._formatter.formatPrice({
+                        <span class="discountedPrice">${from} ${_formatter.formatPrice({
                         value: price.finalPrice,
                         currency: price.currency
-                    })} ${to} ${this._formatter.formatPrice({
+                    })} ${to} ${_formatter.formatPrice({
                         value: price.finalPriceMax,
                         currency: price.currency
                     })}</span>`;
                 } else {
-                    innerHTML += `<span>${from} ${this._formatter.formatPrice({
+                    innerHTML += `<span>${from} ${_formatter.formatPrice({
                         value: price.regularPrice,
                         currency: price.currency
-                    })} ${to} ${this._formatter.formatPrice({
+                    })} ${to} ${_formatter.formatPrice({
                         value: price.regularPriceMax,
                         currency: price.currency
                     })}</span>`;
@@ -170,7 +182,7 @@ class ProductCollection {
             }
 
             item.querySelector(ProductCollection.selectors.price).innerHTML = innerHTML;
-        });
+        }
     }
 
     _applySortKey(sortKeySelect) {
@@ -220,7 +232,7 @@ class ProductCollection {
         // Fetch prices
         if (this._state.loadPrices) {
             this._state.skus = Array.from(moreItems, item => item.dataset.sku);
-            this._fetchPrices();
+            await this._fetchPrices();
         }
     }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/actions.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/actions.html
@@ -16,8 +16,8 @@
 <template data-sly-template.actions ="${@ product}">
     <div class="productteaser__cta" data-sly-test="${product.callToAction != null}">
         <button data-sly-test="${product.callToAction == 'add-to-cart'}" data-action="addToCart" 
-                data-item-sku="${product.sku}" data-cmp-clickable="${product.data ? true : false}"
-                class="button__root_highPriority button__root clickable__root button__filled" type="button">
+                data-item-sku="${product.sku}" class="button__root_highPriority button__root clickable__root button__filled" 
+                type="button">
             <span class="button__content"><span>${product.callToActionText || 'Add to Cart' @ i18n}</span></span>
         </button>
         <button data-sly-test="${product.callToAction == 'details'}" data-action="details" 

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -48,10 +48,7 @@ class ProductTeaser {
                     actionHandler = this._noOpHandler;
             }
 
-            actionButton.addEventListener('click', ev => {
-                const element = ev.currentTarget;
-                actionHandler(element.dataset);
-            });
+            actionButton.addEventListener('click', ev => actionHandler(ev));
         });
     }
 
@@ -59,23 +56,30 @@ class ProductTeaser {
         /* As the name says... NOOP */
     }
 
-    _addToCartHandler(dataset) {
-        const sku = dataset['itemSku'];
+    _addToCartHandler(event) {
+        const target = event.currentTarget;
+        const dataset = target.dataset;
+        const sku = dataset.itemSku;
         const customEvent = new CustomEvent('aem.cif.add-to-cart', {
+            bubbles: true,
             detail: [{ sku, quantity: 1, virtual: this.virtual }]
         });
-        document.dispatchEvent(customEvent);
+        target.dispatchEvent(customEvent);
     }
 
-    _addToWishlistHandler(dataset) {
-        const sku = dataset['itemSku'];
+    _addToWishlistHandler(event) {
+        const target = event.currentTarget;
+        const dataset = target.dataset;
+        const sku = dataset.itemSku;
         const customEvent = new CustomEvent('aem.cif.add-to-wishlist', {
+            bubbles: true,
             detail: [{ sku, quantity: 1 }]
         });
-        document.dispatchEvent(customEvent);
+        target.dispatchEvent(customEvent);
     }
 
-    _seeDetailsHandler(dataset) {
+    _seeDetailsHandler(event) {
+        const dataset = event.currentTarget.dataset;
         const url = dataset['url'];
         const target = dataset['target'];
         if (target) {

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productteaser/v1/productteaser/clientlibs/js/actions.js
@@ -65,6 +65,8 @@ class ProductTeaser {
             detail: [{ sku, quantity: 1, virtual: this.virtual }]
         });
         target.dispatchEvent(customEvent);
+        event.preventDefault();
+        event.stopPropagation();
     }
 
     _addToWishlistHandler(event) {
@@ -76,6 +78,8 @@ class ProductTeaser {
             detail: [{ sku, quantity: 1 }]
         });
         target.dispatchEvent(customEvent);
+        event.preventDefault();
+        event.stopPropagation();
     }
 
     _seeDetailsHandler(event) {

--- a/ui.apps/test/components/commerce/product/v1/addToCartGroupedProductsTest.js
+++ b/ui.apps/test/components/commerce/product/v1/addToCartGroupedProductsTest.js
@@ -93,8 +93,7 @@ describe('GroupedProduct', () => {
 
         it('dispatches add-to-cart event on click', () => {
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
 
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             let selections = Array.from(pageRoot.querySelectorAll(AddToCart.selectors.quantity));
@@ -114,14 +113,11 @@ describe('GroupedProduct', () => {
             assert.equal(event.detail[0].quantity, 1);
             assert.equal(event.detail[1].sku, 'sku3');
             assert.equal(event.detail[1].quantity, 1);
-
-            document.dispatchEvent = _originalDispatch;
         });
 
         it('dispatches add-to-cart event with virtual product on click', () => {
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
 
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             let selections = Array.from(pageRoot.querySelectorAll(AddToCart.selectors.quantity));
@@ -143,8 +139,6 @@ describe('GroupedProduct', () => {
             assert.equal(event.detail[1].sku, 'sku4');
             assert.equal(event.detail[1].quantity, 1);
             assert.isTrue(event.detail[1].virtual);
-
-            document.dispatchEvent = _originalDispatch;
         });
     });
 });

--- a/ui.apps/test/components/commerce/product/v1/addToCartTest.js
+++ b/ui.apps/test/components/commerce/product/v1/addToCartTest.js
@@ -115,16 +115,15 @@ describe('Product', () => {
 
         it('dispatches an event on click', () => {
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
+
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             addToCartRoot.click();
+
             sinon.assert.calledOnce(spy);
-            assert.equal(spy.getCall(0).args[0].type, 'aem.cif.add-to-cart');
             assert.equal(spy.getCall(0).args[0].detail[0].sku, addToCart._state.sku);
             assert.equal(spy.getCall(0).args[0].detail[0].quantity, 5);
             assert.isFalse(spy.getCall(0).args[0].detail[0].virtual);
-            document.dispatchEvent = _originalDispatch;
         });
 
         it('dispatches a virtual add to cart event', () => {
@@ -152,15 +151,13 @@ describe('Product', () => {
             productRoot = pageRoot.querySelector(AddToCart.selectors.product);
 
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
+
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             addToCartRoot.click();
             sinon.assert.calledOnce(spy);
-            assert.equal(spy.getCall(0).args[0].type, 'aem.cif.add-to-cart');
             assert.equal(spy.getCall(0).args[0].detail[0].quantity, 4);
             assert.isTrue(spy.getCall(0).args[0].detail[0].virtual);
-            document.dispatchEvent = _originalDispatch;
         });
     });
 });

--- a/ui.apps/test/components/commerce/product/v1/productTest.js
+++ b/ui.apps/test/components/commerce/product/v1/productTest.js
@@ -130,7 +130,7 @@ describe('Product', () => {
             assert.isFalse(product._state.loadPrices);
         });
 
-        it('changes variant when receiving variantchanged event', () => {
+        it('changes variant when receiving variantchanged event', async () => {
             let product = new Product({ element: productRoot });
 
             // Send event
@@ -148,6 +148,9 @@ describe('Product', () => {
             });
             productRoot.dispatchEvent(changeEvent);
 
+            // wait for the async update to be applied
+            await new Promise(r => setTimeout(r, 20));
+
             // Check state
             assert.equal(product._state.sku, variant.sku);
 
@@ -163,7 +166,7 @@ describe('Product', () => {
             assert.equal(description, variant.description);
         });
 
-        it('changes variant with client-side price when receiving variantchanged event', () => {
+        it('changes variant with client-side price when receiving variantchanged event', async () => {
             let product = new Product({ element: productRoot });
             product._state.prices = {
                 'variant-sku': convertedPrices['sample-sku']
@@ -178,6 +181,9 @@ describe('Product', () => {
                 }
             });
             productRoot.dispatchEvent(changeEvent);
+
+            // wait for the async update to be applied
+            await new Promise(r => setTimeout(r, 20));
 
             // Check fields
             let price = productRoot.querySelector(Product.selectors.price).innerText;

--- a/ui.apps/test/components/commerce/product/v3/addToCartGroupedProductsTest.js
+++ b/ui.apps/test/components/commerce/product/v3/addToCartGroupedProductsTest.js
@@ -99,8 +99,7 @@ describe('GroupedProduct', () => {
 
         it('dispatches add-to-cart event on click', () => {
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
 
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             let selections = Array.from(pageRoot.querySelectorAll(AddToCart.selectors.quantity));
@@ -120,14 +119,11 @@ describe('GroupedProduct', () => {
             assert.equal(event.detail[0].quantity, 1);
             assert.equal(event.detail[1].sku, 'sku3');
             assert.equal(event.detail[1].quantity, 1);
-
-            document.dispatchEvent = _originalDispatch;
         });
 
         it('dispatches add-to-cart event with virtual product on click', () => {
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
 
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             let selections = Array.from(pageRoot.querySelectorAll(AddToCart.selectors.quantity));
@@ -149,8 +145,6 @@ describe('GroupedProduct', () => {
             assert.equal(event.detail[1].sku, 'sku4');
             assert.equal(event.detail[1].quantity, 1);
             assert.isTrue(event.detail[1].virtual);
-
-            document.dispatchEvent = _originalDispatch;
         });
     });
 });

--- a/ui.apps/test/components/commerce/product/v3/addToCartTest.js
+++ b/ui.apps/test/components/commerce/product/v3/addToCartTest.js
@@ -116,16 +116,14 @@ describe('Product', () => {
 
         it('dispatches an event on click', () => {
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
+
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             addToCartRoot.click();
             sinon.assert.calledOnce(spy);
-            assert.equal(spy.getCall(0).args[0].type, 'aem.cif.add-to-cart');
             assert.equal(spy.getCall(0).args[0].detail[0].sku, addToCart._state.sku);
             assert.equal(spy.getCall(0).args[0].detail[0].quantity, 5);
             assert.isFalse(spy.getCall(0).args[0].detail[0].virtual);
-            document.dispatchEvent = _originalDispatch;
         });
 
         it('dispatches a virtual add to cart event', () => {
@@ -154,15 +152,14 @@ describe('Product', () => {
             productRoot = pageRoot.querySelector(AddToCart.selectors.product);
 
             let spy = sinon.spy();
-            let _originalDispatch = document.dispatchEvent;
-            document.dispatchEvent = spy;
+            document.addEventListener('aem.cif.add-to-cart', spy);
+
             let addToCart = new AddToCart({ element: addToCartRoot, product: productRoot });
             addToCartRoot.click();
             sinon.assert.calledOnce(spy);
             assert.equal(spy.getCall(0).args[0].type, 'aem.cif.add-to-cart');
             assert.equal(spy.getCall(0).args[0].detail[0].quantity, 4);
             assert.isTrue(spy.getCall(0).args[0].detail[0].virtual);
-            document.dispatchEvent = _originalDispatch;
         });
     });
 });

--- a/ui.apps/test/components/commerce/productcollection/productCollectionV2Test.js
+++ b/ui.apps/test/components/commerce/productcollection/productCollectionV2Test.js
@@ -264,10 +264,15 @@ describe('Productcollection', () => {
                 </div>
             </div>`
         );
+        document.body.appendChild(listRoot);
 
         window.CIF.CommerceGraphqlApi = {
             getProductPrices: sinon.stub().resolves(clientPrices)
         };
+    });
+
+    afterEach(() => {
+        document.body.childNodes.forEach(node => node.remove());
     });
 
     it('initializes a product list component', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change adds a `path` property to the `eventInfo` object for the `cif:addToCart` and `cif:addToWishList` datalayer events. 

It includes in particular:

- Datalayer implementation for Product Recommendations. This was just missing, but needed to have it consistently implemented for all component that have an add to cart / add to wish list button
- `aem.cif.add-to-cart` and `aem.cif.add-to-wishlist` are now dispatched on the target element the click originated from and bubble up to the listeners usually added to the `document`. This allows us to find the data layer component for the event by looking at it's target element in a central place and we don't have to duplicate the logic to find the data layer component id in every place
- Removal of (redundant) cmp:click events when clicking on addToCart / addToWishList
- Removal of the `@id`

Additionally this PR contains a minor change aligning the "enable add to wishlist controlled by cloud configuration default behaviour" of product carousel and product list with the other components. 

## Related Issue

CIF-2865
Fixes #855
Fixes https://github.com/adobe/aem-cif-guides-venia/issues/265

## Motivation and Context

Consistency for add to cart and add to wishlist events

## How Has This Been Tested?

Unit tests, locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
