### PR TITLE
SITES-6887: fix some resource type to model bindings

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/CurrentPageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/page/CurrentPageImpl.java
@@ -44,7 +44,8 @@ import com.adobe.cq.wcm.core.components.models.Page;
     resourceType = {
         com.adobe.cq.commerce.core.components.internal.models.v1.product.ProductImpl.RESOURCE_TYPE,
         com.adobe.cq.commerce.core.components.internal.models.v2.product.ProductImpl.RESOURCE_TYPE,
-        com.adobe.cq.commerce.core.components.internal.models.v1.productcollection.ProductCollectionImpl.RESOURCE_TYPE
+        com.adobe.cq.commerce.core.components.internal.models.v1.productcollection.ProductCollectionImpl.RESOURCE_TYPE,
+        com.adobe.cq.commerce.core.components.internal.models.v1.productcollection.ProductCollectionImpl.RESOURCE_TYPE_V2
     })
 public class CurrentPageImpl extends AbstractPageDelegator {
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcollection/ProductCollectionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/productcollection/ProductCollectionImpl.java
@@ -57,6 +57,7 @@ import static com.adobe.cq.commerce.core.search.internal.models.SearchOptionsImp
 public class ProductCollectionImpl extends DataLayerComponent implements ProductCollection {
 
     public static final String RESOURCE_TYPE = "core/cif/components/commerce/productcollection/v1/productcollection";
+    public static final String RESOURCE_TYPE_V2 = "core/cif/components/commerce/productcollection/v2/productcollection";
 
     protected static final boolean LOAD_CLIENT_PRICE_DEFAULT = true;
     protected static final boolean ENABLE_ADD_TO_CART_DEFAULT = false;

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/searchresults/SearchResultsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/searchresults/SearchResultsImpl.java
@@ -45,10 +45,11 @@ import com.adobe.cq.commerce.core.search.models.Sorter;
 @Model(
     adaptables = SlingHttpServletRequest.class,
     adapters = SearchResults.class,
-    resourceType = SearchResultsImpl.RESOURCE_TYPE)
+    resourceType = { SearchResultsImpl.RESOURCE_TYPE, SearchResultsImpl.RESOURCE_TYPE_V2 })
 public class SearchResultsImpl extends ProductCollectionImpl implements SearchResults {
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchResultsImpl.class);
-    static final String RESOURCE_TYPE = "core/cif/components/commerce/searchresults";
+    static final String RESOURCE_TYPE = "core/cif/components/commerce/searchresults/v1/searchresults";
+    static final String RESOURCE_TYPE_V2 = "core/cif/components/commerce/searchresults/v2/searchresults";
 
     private String searchTerm;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR update the resource type binding of the `CurrentPageImpl` and the `SearchResultsImpl`.

With https://github.com/adobe/aem-core-wcm-components/pull/2246 the `LatestVersionImplementationPicker` will adapt the productlist v2 request not to the `CurrentPageImpl` but to the Page v3 model instead. This should not have any affect yet, however it may be missed in the future when using other methods added to Page in CIF in the future. 

## Related Issue

https://github.com/adobe/aem-core-wcm-components/pull/2246

## Motivation and Context

We should make sure that the resource type binding of our models is correct to prevent situations where the models class would inject itself in a recursive way and so cause issues.

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
