### PR TITLE
CIF-2673 - Add navRoot checkbox to page properties

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/ShowNavRootRenderConditionServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/ShowNavRootRenderConditionServlet.java
@@ -1,0 +1,78 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.commerce.core.components.internal.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.adobe.cq.commerce.core.components.internal.services.site.SiteStructureFactory;
+import com.adobe.cq.commerce.core.components.models.common.SiteStructure;
+import com.adobe.granite.ui.components.rendercondition.RenderCondition;
+import com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+
+/**
+ * {@code ShowNavRootRenderConditionServlet} implements a {@code granite:rendercondition} used to determine if the navRoot option should be
+ * displayed on the properties page of a page.
+ */
+@Component(
+    service = { Servlet.class },
+    property = {
+        "sling.servlet.resourceTypes=" + ShowNavRootRenderConditionServlet.RESOURCE_TYPE,
+        "sling.servlet.methods=GET",
+        "sling.servlet.extensions=html"
+    })
+public class ShowNavRootRenderConditionServlet extends SlingSafeMethodsServlet {
+    public final static String RESOURCE_TYPE = "core/cif/components/renderconditions/showNavRoot";
+
+    @Reference
+    private SiteStructureFactory siteStructureFactory;
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
+        throws ServletException, IOException {
+        request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(showNavRoot(request)));
+    }
+
+    private boolean showNavRoot(SlingHttpServletRequest request) {
+        PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
+        if (pageManager == null) {
+            return false;
+        }
+
+        String pagePath = request.getParameter("item");
+        Page page = pageManager.getPage(pagePath);
+        if (page == null) {
+            return false;
+        }
+
+        SiteStructure siteStructure = siteStructureFactory.getSiteStructure(page);
+        Page landingPage = siteStructure.getLandingPage();
+
+        // Show navRoot option if there is no landing page or if the current page is the landing page.
+        return landingPage == null || landingPage.equals(page);
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/ShowNavRootRenderConditionServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/ShowNavRootRenderConditionServletTest.java
@@ -1,0 +1,92 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.commerce.core.components.internal.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
+import org.apache.sling.servlethelpers.MockSlingHttpServletResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.adobe.granite.ui.components.rendercondition.RenderCondition;
+import com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition;
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+import static com.adobe.cq.commerce.core.testing.TestContext.newAemContext;
+import static org.mockito.Mockito.mock;
+
+public class ShowNavRootRenderConditionServletTest {
+
+    @Rule
+    public final AemContext context = newAemContext("/context/SiteStructureImplTest/jcr-content.json");
+
+    private MockSlingHttpServletRequest request;
+    private MockSlingHttpServletResponse response;
+    private ShowNavRootRenderConditionServlet servlet;
+
+    @Before
+    public void setUp() {
+        response = new MockSlingHttpServletResponse();
+        request = new MockSlingHttpServletRequest(context.resourceResolver());
+        Resource resource = mock(Resource.class);
+        request.setResource(resource);
+        request.setPathInfo("/mnt/overlay/wcm/core/content/sites/properties.html");
+
+        servlet = context.registerInjectActivateService(new ShowNavRootRenderConditionServlet());
+    }
+
+    @Test
+    public void testReturnsTrueForLandingPageEqualsPage() throws ServletException, IOException {
+        request.setQueryString("item=/content/nav-root");
+        servlet.doGet(request, response);
+
+        SimpleRenderCondition condition = (SimpleRenderCondition) request.getAttribute(RenderCondition.class.getName());
+        Assert.assertTrue(condition.check());
+    }
+
+    @Test
+    public void testReturnsTrueForNoLandingPage() throws ServletException, IOException {
+        request.setQueryString("item=/content/no-nav-root");
+        servlet.doGet(request, response);
+
+        SimpleRenderCondition condition = (SimpleRenderCondition) request.getAttribute(RenderCondition.class.getName());
+        Assert.assertTrue(condition.check());
+    }
+
+    @Test
+    public void testReturnsFalseForDefinedLandingPage() throws ServletException, IOException {
+        request.setQueryString("item=/content/nav-root/content-page");
+        servlet.doGet(request, response);
+
+        SimpleRenderCondition condition = (SimpleRenderCondition) request.getAttribute(RenderCondition.class.getName());
+        Assert.assertFalse(condition.check());
+    }
+
+    @Test
+    public void testReturnsFalseForInvalidPage() throws ServletException, IOException {
+        request.setQueryString("item=/content/does-not-exist");
+        servlet.doGet(request, response);
+
+        SimpleRenderCondition condition = (SimpleRenderCondition) request.getAttribute(RenderCondition.class.getName());
+        Assert.assertFalse(condition.check());
+    }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -47,6 +47,8 @@
                                             <categoryPageCondition jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                 pageType="category"/>
+                                            <navRootCondition jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
                                         </granite:rendercondition>
                                         <items jcr:primaryType="nt:unstructured">
                                             <products

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v1/page/_cq_dialog/.content.xml
@@ -130,8 +130,21 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                 pageType="product"/>
+                                            <navRootCondition jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
                                         </granite:rendercondition>
                                         <items jcr:primaryType="nt:unstructured">
+                                            <navRoot
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                fieldDescription="Make this page the landing page of your site."
+                                                name="./navRoot"
+                                                text="Landing Page"
+                                                uncheckedValue="false"
+                                                value="true">
+                                                <granite:rendercondition jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
+                                            </navRoot>
                                             <categoryFilter jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="commerce/gui/components/common/cifcategoryfield"
                                                 fieldDescription="Category ids for which this page will be used."

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -47,6 +47,8 @@
                                             <categoryPageCondition jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                 pageType="category"/>
+                                            <navRootCondition jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
                                         </granite:rendercondition>
                                         <items jcr:primaryType="nt:unstructured">
                                             <products

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v2/page/_cq_dialog/.content.xml
@@ -154,8 +154,21 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                 pageType="product"/>
+                                            <navRootCondition jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
                                         </granite:rendercondition>
                                         <items jcr:primaryType="nt:unstructured">
+                                            <navRoot
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                fieldDescription="Make this page the landing page of your site."
+                                                name="./navRoot"
+                                                text="Landing Page"
+                                                uncheckedValue="false"
+                                                value="true">
+                                                <granite:rendercondition jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
+                                            </navRoot>
                                             <productFilter jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                 fieldDescription="Product slugs for which this page will be used."

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v3/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v3/page/_cq_dialog/.content.xml
@@ -47,6 +47,8 @@
                                             <categoryPageCondition jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                 pageType="category"/>
+                                            <navRootCondition jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
                                         </granite:rendercondition>
                                         <items jcr:primaryType="nt:unstructured">
                                             <products

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v3/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/structure/page/v3/page/_cq_dialog/.content.xml
@@ -150,12 +150,24 @@
                                             <categoryPageCondition jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                 pageType="category"/>
-                                            <productPageCondition
-                                                jcr:primaryType="nt:unstructured"
+                                            <productPageCondition jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="core/cif/components/renderconditions/pagetype"
                                                 pageType="product"/>
+                                            <navRootCondition jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
                                         </granite:rendercondition>
                                         <items jcr:primaryType="nt:unstructured">
+                                            <navRoot
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                fieldDescription="Make this page the landing page of your site."
+                                                name="./navRoot"
+                                                text="Landing Page"
+                                                uncheckedValue="false"
+                                                value="true">
+                                                <granite:rendercondition jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="core/cif/components/renderconditions/showNavRoot"/>
+                                            </navRoot>
                                             <productFilter jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="commerce/gui/components/common/cifproductfield"
                                                 fieldDescription="Product slugs for which this page will be used."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Added `Landing Page` checkbox to properties page of CIF page component (v1, v2 and v3).
* Added `ShowNavRootRenderConditionServlet` to show checkbox only on pages that are either the landing page or don't have a landing page in the hierarchy.
* Added unit tests.

## How Has This Been Tested?

* UI tests in Venia

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
