### PR TITLE
CIF-2948: parse response html in the current browsing context

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v1/productcollection/clientlibs/js/productcollection.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v1/productcollection/clientlibs/js/productcollection.js
@@ -115,8 +115,7 @@ class ProductCollection {
 
         // Parse response and only select product items
         let text = await response.text();
-        let domParser = new DOMParser();
-        let more = domParser.parseFromString(text, 'text/html');
+        let more = document.createRange().createContextualFragment(text);
         let moreItems = more.querySelectorAll(ProductCollection.selectors.item);
 
         // Append new product items to existing product gallery

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/productcollection.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/productcollection.js
@@ -129,8 +129,7 @@ class ProductCollection {
 
         // Parse response and only select product items
         let text = await response.text();
-        let domParser = new DOMParser();
-        let more = domParser.parseFromString(text, 'text/html');
+        let more = document.createRange().createContextualFragment(text);
         let moreItems = more.querySelectorAll(
             ProductCollection.selectors.item + ', ' + ProductCollection.selectors.xfitem
         );

--- a/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/productcollection.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/cif/components/commerce/productcollection/v2/productcollection/clientlibs/js/productcollection.js
@@ -134,7 +134,6 @@ class ProductCollection {
             ProductCollection.selectors.item + ', ' + ProductCollection.selectors.xfitem
         );
 
-        console.log('more', more, 'moreItems', moreItems);
         // Append new product items to existing product gallery
         let galleryItems = this._element.querySelector(ProductCollection.selectors.galleryItems);
         galleryItems.append(...moreItems);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change replaces the use of DOMParser in the load more handlers of product collections with a [`document.createRange().createContextualFragment`](https://developer.mozilla.org/en-US/docs/Web/API/Range/createContextualFragment). 

The DOMParser previously parsed the returned html without any browsing context, hence flagged as scripting disabled. This causes all nodes in `<noscript>` tags to be parsed as dom nodes. 

The image v2 component on the other hand expects the content of the `<noscript>` tag to be pure text, which is the expected for javascript enabled browsers. Because of this the image v2 component was not working for product list experience fragments in combination with load more yet.

## Related Issue

CIF-2948

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally, existing uint tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
