### PR TITLE
fix: add Page v3 resource type to CatalogPageNotFoundFilter and redirect servlets

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilter.java
@@ -61,6 +61,8 @@ import com.day.cq.wcm.api.PageManagerFactory;
             + com.adobe.cq.commerce.core.components.internal.models.v1.page.PageImpl.RESOURCE_TYPE,
         EngineConstants.SLING_FILTER_RESOURCETYPES + "="
             + com.adobe.cq.commerce.core.components.internal.models.v2.page.PageImpl.RESOURCE_TYPE,
+        EngineConstants.SLING_FILTER_RESOURCETYPES + "="
+            + com.adobe.cq.commerce.core.components.internal.models.v3.page.PageImpl.RESOURCE_TYPE,
         // limit to typical content rendering requests
         EngineConstants.SLING_FILTER_EXTENSIONS + "=html",
         EngineConstants.SLING_FILTER_EXTENSIONS + "=json",

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/CategoryPageRedirectServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/CategoryPageRedirectServlet.java
@@ -43,6 +43,8 @@ import com.day.cq.wcm.api.PageManagerFactory;
             + com.adobe.cq.commerce.core.components.internal.models.v1.page.PageImpl.RESOURCE_TYPE,
         ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES + "="
             + com.adobe.cq.commerce.core.components.internal.models.v2.page.PageImpl.RESOURCE_TYPE,
+        ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES + "="
+            + com.adobe.cq.commerce.core.components.internal.models.v3.page.PageImpl.RESOURCE_TYPE,
         ServletResolverConstants.SLING_SERVLET_SELECTORS + "=" + CategoryPageRedirectServlet.SELECTOR,
         ServletResolverConstants.SLING_SERVLET_EXTENSIONS + "=" + CategoryPageRedirectServlet.EXTENSION
     })

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/ProductPageRedirectServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/ProductPageRedirectServlet.java
@@ -42,6 +42,8 @@ import com.day.cq.wcm.api.PageManagerFactory;
             + com.adobe.cq.commerce.core.components.internal.models.v1.page.PageImpl.RESOURCE_TYPE,
         ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES + "="
             + com.adobe.cq.commerce.core.components.internal.models.v2.page.PageImpl.RESOURCE_TYPE,
+        ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES + "="
+            + com.adobe.cq.commerce.core.components.internal.models.v3.page.PageImpl.RESOURCE_TYPE,
         ServletResolverConstants.SLING_SERVLET_SELECTORS + "=" + ProductPageRedirectServlet.SELECTOR,
         ServletResolverConstants.SLING_SERVLET_EXTENSIONS + "=" + ProductPageRedirectServlet.EXTENSION
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some of the servlets and filters are not yet registered for the Page v3 resource type. The functionality provided by them is missing.

## Related Issue

#987 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
