### PR TITLE
SITES-17412: Log WARN when getting duplicate id from Magento GraphQL API

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractCategoriesRetriever.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/retriever/AbstractCategoriesRetriever.java
@@ -17,11 +17,15 @@ package com.adobe.cq.commerce.core.components.models.retriever;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.commerce.core.components.client.MagentoGraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
@@ -36,6 +40,8 @@ import com.adobe.cq.commerce.magento.graphql.QueryQuery;
 import com.adobe.cq.commerce.magento.graphql.gson.Error;
 
 public abstract class AbstractCategoriesRetriever extends AbstractRetriever {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCategoriesRetriever.class);
 
     public static final String CATEGORY_IMAGE_FOLDER = "catalog/category/";
 
@@ -194,6 +200,21 @@ public abstract class AbstractCategoriesRetriever extends AbstractRetriever {
             categories.sort(Comparator.comparing(c -> identifiers.indexOf(c.getUid().toString())));
         } else {
             categories = Collections.emptyList();
+        }
+        logDuplicateCategories();
+    }
+
+    private void logDuplicateCategories() {
+        if (categories == null) {
+            return;
+        }
+        Set<String> categoryIds = new HashSet<>();
+        for (CategoryTree category : categories) {
+            String uid = category.getUid().toString();
+            if (categoryIds.contains(uid)) {
+                LOGGER.warn("Duplicate category detected: {}", uid);
+            }
+            categoryIds.add(uid);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Log WARN when getting duplicate id from Magento GraphQL API
## Description

Log WARN when getting duplicate id from Magento GraphQL API

## Related Issue
https://jira.corp.adobe.com/browse/SITES-17412

## Motivation and Context

There exists a way to get duplicate data from Magento GraphQL API, this possibility occurs when customers add data to their system and the indexers do not complete before data is retrieved from the system.

 

Do It Best was affected by this and the AEM Support Org spent weeks debugging (because it was also a very intermittent issue). Eventually, T3 deployed a custom build of the Category Feature List showcasing the GraphQL query and we discovered that the categoryIds were unique. After engaging and reviewing our findings with SITES engineering we agreed to log a ticket with Magneto Engineering which then Magento ack'd that this can occur.

 

The CIF should log a WARN in the logs to help inform the customer that they need to fix the data in their Magento instance so that their site is not showcasing incorrect data. 

 

In the situation where the customer has [^components .content.doitbest.us.en.global.homepage.jcr-content.root.json] we should check that the resulting GraphQL response does not contain duplicate categoryId or else this would be an issue.
## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
