### PR TITLE
SITES-39761 - NavigationItem.getLink() returns null in CIF v2 Navigation component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java
@@ -47,6 +47,7 @@ import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.core.components.services.urls.CategoryUrlFormat;
 import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
+import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.launches.utils.LaunchUtils;
 import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
 import com.day.cq.commons.inherit.InheritanceValueMap;
@@ -248,6 +249,11 @@ public class NavigationImpl implements Navigation {
                 addItems(pageManager, this, item, items);
             }
             return items;
+        }
+
+        @Override
+        public Link getLink() {
+            return wcmItem.getLink();
         }
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v2/navigation/NavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v2/navigation/NavigationItemImpl.java
@@ -18,6 +18,7 @@ package com.adobe.cq.commerce.core.components.internal.models.v2.navigation;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 
 class NavigationItemImpl implements NavigationItem {
@@ -61,5 +62,10 @@ class NavigationItemImpl implements NavigationItem {
     @Override
     public int getLevel() {
         return level;
+    }
+
+    @Override
+    public Link getLink() {
+        return commerceNavigationItem.getLink();
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/navigation/NavigationItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/navigation/NavigationItem.java
@@ -17,6 +17,10 @@ package com.adobe.cq.commerce.core.components.models.navigation;
 
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
+import com.adobe.cq.wcm.core.components.commons.link.Link;
+
 /**
  * Simple data model for a navigation item of the navigation component.
  */
@@ -41,4 +45,19 @@ public interface NavigationItem {
      * @return The navigation items to be rendered by the navigation component.
      */
     List<NavigationItem> getItems();
+
+    /**
+     * Returns the link for this navigation item.
+     * <p>
+     * For page-based navigation items, this returns the link to the underlying page,
+     * including any link attributes such as target. For category-based navigation items,
+     * this may return {@code null}.
+     *
+     * @return the {@link Link} object for this navigation item, or {@code null} if not available
+     * @since 2.7.0
+     */
+    @Nullable
+    default Link getLink() {
+        return null;
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/navigation/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/navigation/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.13.0")
+@Version("1.14.0")
 package com.adobe.cq.commerce.core.components.models.navigation;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImplTest.java
@@ -43,6 +43,7 @@ import com.adobe.cq.commerce.core.components.models.navigation.Navigation;
 import com.adobe.cq.commerce.core.components.models.navigation.NavigationModel;
 import com.adobe.cq.commerce.core.components.services.ComponentsConfiguration;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
+import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
@@ -610,5 +611,64 @@ public class NavigationImplTest {
 
         when(catalogPage.adaptTo(ComponentsConfiguration.class)).thenReturn(new ComponentsConfiguration(configProperties));
         when(siteStructure.isCatalogPage(catalogPage)).thenReturn(Boolean.TRUE);
+    }
+
+    @Test
+    public void testNavigationPageItemGetLink() {
+        // Test that page-based navigation items return the link from the underlying WCM item
+
+        String pageTitle = "Page 1";
+        String pageURL = "/page1";
+        boolean active = true;
+
+        NavigationItem item = mock(NavigationItem.class);
+        when(item.getTitle()).thenReturn(pageTitle);
+        when(item.getURL()).thenReturn(pageURL);
+        when(item.isActive()).thenReturn(active);
+
+        // Mock the Link object
+        Link mockLink = mock(Link.class);
+        when(mockLink.getURL()).thenReturn(pageURL);
+        when(item.getLink()).thenReturn(mockLink);
+
+        navigationItems.add(item);
+
+        List<com.adobe.cq.commerce.core.components.models.navigation.NavigationItem> items = navigation.getItems();
+        Assert.assertEquals(1, items.size());
+        com.adobe.cq.commerce.core.components.models.navigation.NavigationItem navigationItem = items.get(0);
+
+        // Verify that getLink() returns the link from the underlying WCM item
+        Link link = navigationItem.getLink();
+        Assert.assertNotNull("getLink() should return a non-null Link for page-based navigation items", link);
+        Assert.assertEquals(pageURL, link.getURL());
+    }
+
+    @Test
+    public void testNavigationCategoryItemGetLinkReturnsNull() {
+        // Test that category-based navigation items return null for getLink()
+
+        String categoryId = "uid-0";
+        String categoryUrlPath = "category-1";
+        String categoryName = "Category 1";
+
+        initCatalogPage(true, true, false);
+
+        NavigationItem item = mock(NavigationItem.class);
+        when(item.getPath()).thenReturn(CATALOG_PAGE_PATH);
+        navigationItems.add(item);
+
+        CategoryTree category = mock(CategoryTree.class);
+        when(category.getUid()).thenReturn(new ID(categoryId));
+        when(category.getUrlPath()).thenReturn(categoryUrlPath);
+        when(category.getName()).thenReturn(categoryName);
+        categoryList.add(category);
+
+        List<com.adobe.cq.commerce.core.components.models.navigation.NavigationItem> items = navigation.getItems();
+        Assert.assertEquals(1, items.size());
+        com.adobe.cq.commerce.core.components.models.navigation.NavigationItem navigationItem = items.get(0);
+
+        // Verify that getLink() returns null for category-based navigation items
+        Link link = navigationItem.getLink();
+        Assert.assertNull("getLink() should return null for category-based navigation items", link);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v2/navigation/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v2/navigation/NavigationImplTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import com.adobe.cq.commerce.core.testing.MockPathProcessor;
 import com.adobe.cq.commerce.core.testing.Utils;
 import com.adobe.cq.sightly.SightlyWCMMode;
+import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.models.Navigation;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
@@ -107,5 +108,24 @@ public class NavigationImplTest {
 
         Assert.assertNotNull(children);
         Assert.assertEquals(2, children.size());
+    }
+
+    @Test
+    public void testNavigationItemGetLink() {
+        Navigation navigation = context.request().adaptTo(Navigation.class);
+
+        Assert.assertNotNull(navigation);
+
+        List<NavigationItem> items = navigation.getItems();
+        Assert.assertNotNull(items);
+        Assert.assertEquals(1, items.size());
+
+        NavigationItem item = items.get(0);
+        Assert.assertNotNull(item);
+
+        // Verify that getLink() returns a non-null Link for page-based navigation items
+        Link link = item.getLink();
+        Assert.assertNotNull("getLink() should return a non-null Link for page-based navigation items", link);
+        Assert.assertEquals("/content/pageA/pageB.html", link.getURL());
     }
 }


### PR DESCRIPTION
## Problem

`NavigationItem.getLink()` returns `null` in the CIF v2 Navigation component, preventing access to `currentPage` and related properties like "target blank".

**GitHub Issue:** #1049

## Root Cause

The v2 `NavigationItemImpl` class implements the WCM Core Components `NavigationItem` interface (which extends `ListItem`), but does not override the `getLink()` method. The `ListItem.getLink()` method (available since WCM Core Components 12.20.0) returns `null` by default.

The underlying CIF `NavigationItem` interface (`com.adobe.cq.commerce.core.components.models.navigation.NavigationItem`) does not have a `getLink()` method, so there's no way to delegate to it.

## Changes

1. **Extended CIF NavigationItem interface** - Added a default `getLink()` method returning `null` (backward compatible)
2. **Updated v1 PageNavigationItem** - Override `getLink()` to return `wcmItem.getLink()` (the WCM item already has the link)
3. **Updated v2 NavigationItemImpl** - Override `getLink()` to delegate to `commerceNavigationItem.getLink()`
4. **Added tests** - Verified `getLink()` behavior for page-based and category-based navigation items

## Files Changed

- `bundles/core/src/main/java/com/adobe/cq/commerce/core/components/models/navigation/NavigationItem.java`
- `bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImpl.java`
- `bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/models/v2/navigation/NavigationItemImpl.java`
- `bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v1/navigation/NavigationImplTest.java`
- `bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/models/v2/navigation/NavigationImplTest.java`

## Testing

All existing tests pass, and new tests have been added to verify:
- Page-based navigation items return the link from the underlying WCM item
- Category-based navigation items return `null` for `getLink()` (expected behavior)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author