### PR TITLE
SITES-42445 - Release CIF components 2.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The latest version of the AEM CIF Core Components, require the below minimum sys
 
 | CIF Core Components | AEM as a Cloud Service | AEM 6.5 | AEM Commerce Add-On | Adobe Commerce | Java  |
 |---------------------| ---------------------- | ------- |---------------------| -------------- | ----- |
-| 2.18.0              | Continual              | 6.5.18   | v2025.09.02.00      | 2.4.2 ee       |  11 |
+| 2.18.2              | Continual              | 6.5.18   | v2025.09.02.00      | 2.4.2 ee       |  11 |
 
 For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ See below for a full list of minimum system requirements for historical versions
 
 | CIF Core Components | AEM as a Cloud Service | AEM 6.4 | AEM 6.5 | AEM Commerce Add-On | Magento                    | Java  |
 |---------------------| ---------------------- | ------- | ------- |---------------------| -------------------------- | ----- |
+| 2.18.2              | Continual              |    -    | 6.5.18   | v2025.09.02.00      | 2.4.2 ee                   |   11 |
 | 2.18.0              | Continual              |    -    | 6.5.18   | v2025.09.02.00      | 2.4.2 ee                   |   11 |
 | 2.17.2              | Continual              |    -    | 6.5.18   | v2025.09.02.00      | 2.4.2 ee                   |   11 |
 | 2.16.4              | Continual              |    -    | 6.5.18   | v2022.08.02.00      | 2.4.2 ee                   |   11 |


### PR DESCRIPTION
## Summary
- update README to advertise CIF Core Components 2.18.2 as the latest release
- add 2.18.2 to VERSIONS.md historical system requirements

## Related Issue
- SITES-42445

## Testing
- not run (docs-only change)