### PR TITLE
SITES-43978 Publish returns 404

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilter.java
@@ -25,6 +25,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
@@ -102,6 +103,18 @@ public class CatalogPageNotFoundFilter implements Filter {
 
         SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) servletRequest;
         SlingHttpServletResponse slingResponse = (SlingHttpServletResponse) servletResponse;
+
+        // Skip content-tree reads: the filter validates page-level rendering requests only.
+        // Anything resolving to jcr:content or a descendant is either a raw data read
+        // (DefaultGetServlet) or a sub-component render, neither of which carries the
+        // SKU/category context required here.
+        String path = slingRequest.getResource().getPath();
+        String jcrContentSegment = "/" + JcrConstants.JCR_CONTENT;
+        if (path.endsWith(jcrContentSegment) || path.contains(jcrContentSegment + "/")) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
         PageManager pageManager = pageManagerFactory.getPageManager(slingRequest.getResourceResolver());
         Page currentPage = pageManager.getContainingPage(slingRequest.getResource());
 

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilterTest.java
@@ -119,6 +119,16 @@ public class CatalogPageNotFoundFilterTest {
         Utils.setupHttpResponse(null, httpClient, HttpStatus.SC_NOT_FOUND, "{eq:\"does-not-exist\"}}");
     }
 
+    /**
+     * AEM mocks resolve {@code currentPage} to the page's {@code jcr:content} resource; the production filter must
+     * still validate catalog pages when the request resource is the {@code cq:Page} node (REQUEST scope before forward).
+     */
+    private void currentPageAsPageResource(String pagePath) {
+        aemContext.currentPage(pagePath);
+        Resource pageResource = aemContext.resourceResolver().getResource(pagePath);
+        request.setResource(pageResource);
+    }
+
     @Test
     public void testNoopOnNonCatalogPages() throws ServletException, IOException {
         aemContext.currentPage("/content/venia/us/en");
@@ -144,7 +154,7 @@ public class CatalogPageNotFoundFilterTest {
 
     @Test
     public void testReturns200ForProduct() throws ServletException, IOException {
-        aemContext.currentPage("/content/venia/us/en/products/product-page");
+        currentPageAsPageResource("/content/venia/us/en/products/product-page");
         ((MockRequestPathInfo) request.getRequestPathInfo()).setSuffix("/beaumont-summit-kit.html");
 
         subject.doFilter(request, response, filterChain);
@@ -157,7 +167,7 @@ public class CatalogPageNotFoundFilterTest {
 
     @Test
     public void testReturns200ForCategory() throws ServletException, IOException {
-        aemContext.currentPage("/content/venia/us/en/products/category-page");
+        currentPageAsPageResource("/content/venia/us/en/products/category-page");
         ((MockRequestPathInfo) request.getRequestPathInfo()).setSuffix("/men/tops-men/jackets-men.html");
 
         subject.doFilter(request, response, filterChain);
@@ -194,7 +204,7 @@ public class CatalogPageNotFoundFilterTest {
 
     @Test
     public void testReturns404ForMissingProduct() throws ServletException, IOException {
-        aemContext.currentPage("/content/venia/us/en/products/product-page");
+        currentPageAsPageResource("/content/venia/us/en/products/product-page");
         ((MockRequestPathInfo) request.getRequestPathInfo()).setSuffix("/does-not-exist.html");
 
         subject.doFilter(request, response, filterChain);
@@ -207,7 +217,7 @@ public class CatalogPageNotFoundFilterTest {
 
     @Test
     public void testReturns404ForMissingCategory() throws ServletException, IOException {
-        aemContext.currentPage("/content/venia/us/en/products/category-page");
+        currentPageAsPageResource("/content/venia/us/en/products/category-page");
         ((MockRequestPathInfo) request.getRequestPathInfo()).setSuffix("/does-not-exist.html");
 
         subject.doFilter(request, response, filterChain);
@@ -221,7 +231,7 @@ public class CatalogPageNotFoundFilterTest {
     @Test
     public void testReturns200ForMissingProductWithWcmModeNotDisabled() throws ServletException, IOException {
         when(wcmMode.isDisabled()).thenReturn(false);
-        aemContext.currentPage("/content/venia/us/en/products/product-page");
+        currentPageAsPageResource("/content/venia/us/en/products/product-page");
         ((MockRequestPathInfo) request.getRequestPathInfo()).setSuffix("/does-not-exist.html");
 
         subject.doFilter(request, response, filterChain);
@@ -235,7 +245,7 @@ public class CatalogPageNotFoundFilterTest {
     @Test
     public void testReturns200ForMissingCategoryWithWcmModeNotDisabled() throws ServletException, IOException {
         when(wcmMode.isDisabled()).thenReturn(false);
-        aemContext.currentPage("/content/venia/us/en/products/category-page");
+        currentPageAsPageResource("/content/venia/us/en/products/category-page");
         ((MockRequestPathInfo) request.getRequestPathInfo()).setSuffix("/does-not-exist.html");
 
         subject.doFilter(request, response, filterChain);

--- a/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/commerce/core/components/internal/servlets/CatalogPageNotFoundFilterTest.java
@@ -169,6 +169,30 @@ public class CatalogPageNotFoundFilterTest {
     }
 
     @Test
+    public void testJcrContentRequestPassesThrough() throws ServletException, IOException {
+        aemContext.currentResource("/content/venia/us/en/products/product-page/jcr:content");
+
+        subject.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(contentModelFinder, never()).findProductComponentModel(any(), any());
+        verify(contentModelFinder, never()).findProductListComponentModel(any(), any());
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testJcrContentDescendantRequestPassesThrough() throws ServletException, IOException {
+        aemContext.currentResource("/content/venia/us/en/products/product-page/jcr:content/root");
+
+        subject.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(contentModelFinder, never()).findProductComponentModel(any(), any());
+        verify(contentModelFinder, never()).findProductListComponentModel(any(), any());
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
     public void testReturns404ForMissingProduct() throws ServletException, IOException {
         aemContext.currentPage("/content/venia/us/en/products/product-page");
         ((MockRequestPathInfo) request.getRequestPathInfo()).setSuffix("/does-not-exist.html");


### PR DESCRIPTION
Summary
Fix a regression where requests resolving to jcr:content (or any descendant) on CIF catalog pages could incorrectly return HTTP 404 from CatalogPageNotFoundFilter.

Problem
CatalogPageNotFoundFilter is intended to validate page-level rendering requests that carry product/category context in the URL (for example, a PDP request with a suffix containing the SKU/url_key).

However, the filter was also invoked for raw content-tree reads such as:

.../product-page/jcr:content.json
.../product-page/jcr:content/root.json
(and similarly for any subcomponent under jcr:content)
Those requests do not carry SKU/category context, so the filter could end up adapting product/category models without the required URL context and return 404, even though the content exists.


Fix
Add an early guard at the top of doFilter() to short-circuit when the request resource path is jcr:content or a descendant:

If the resource path ends with "/jcr:content" or contains "/jcr:content/", the filter simply calls filterChain.doFilter(...) and returns.
This ensures the filter only validates page-level requests, and does not interfere with raw content reads or subcomponent renders under jcr:content.