### PR TITLE
SITES-45016 - Release CIF components 2.18.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The latest version of the AEM CIF Core Components, require the below minimum sys
 
 | CIF Core Components | AEM as a Cloud Service | AEM 6.5 | AEM Commerce Add-On | Adobe Commerce | Java  |
 |---------------------| ---------------------- | ------- |---------------------| -------------- | ----- |
-| 2.18.2              | Continual              | 6.5.18   | v2025.09.02.00      | 2.4.2 ee       |  11 |
+| 2.18.4              | Continual              | 6.5.18   | v2025.09.02.00      | 2.4.2 ee       |  11 |
 
 For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ See below for a full list of minimum system requirements for historical versions
 
 | CIF Core Components | AEM as a Cloud Service | AEM 6.4 | AEM 6.5 | AEM Commerce Add-On | Magento                    | Java  |
 |---------------------| ---------------------- | ------- | ------- |---------------------| -------------------------- | ----- |
+| 2.18.4              | Continual              |    -    | 6.5.18   | v2025.09.02.00      | 2.4.2 ee                   |   11 |
 | 2.18.2              | Continual              |    -    | 6.5.18   | v2025.09.02.00      | 2.4.2 ee                   |   11 |
 | 2.18.0              | Continual              |    -    | 6.5.18   | v2025.09.02.00      | 2.4.2 ee                   |   11 |
 | 2.17.2              | Continual              |    -    | 6.5.18   | v2025.09.02.00      | 2.4.2 ee                   |   11 |


### PR DESCRIPTION
## Description

Documentation updates for the AEM CIF Core Components **2.18.4** release.

* Updated `README.md` to advertise 2.18.4 as the latest release in the minimum-system-requirements table.
* Added a 2.18.4 row to `VERSIONS.md` historical system requirements.

## Related Issue

SITES-45016

## Verification

Docs-only change. `2.18.4` artifacts have been verified on Maven Central:
`https://repo1.maven.org/maven2/com/adobe/commerce/cif/core-cif-components-all/2.18.4/`


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author